### PR TITLE
Added validation for untransmute input

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -360,12 +360,14 @@ const convertToJSON = function (o: unknown, metaInfo: MetaInfo) {
 
 export function unTransmute(o: unknown | unknown[]): IStringIndex | IStringIndex[] {
     if (Array.isArray(o)) {
-        return o.map((entry) => {
-            if (hasObjectMetaInfo(entry)) {
-                return convertToJSON(entry, entry.getMetaInfo());
-            }
-            return {};
-        });
+        if (o.length > 0) {
+            return o.map((entry) => {
+                if (hasObjectMetaInfo(entry)) {
+                    return convertToJSON(entry, entry.getMetaInfo());
+                }
+                throw ERRORS.META_INFO_MISSING;
+            });
+        }
     }
     if (getTypeOfObject(o) === 'object') {
         if (hasObjectMetaInfo(o)) {


### PR DESCRIPTION
Now,
- we check the length of array input
- we throw meta info missing exception while untransmuting an array of transmuted objects