### PR TITLE
feat(16): Add support for validation rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "npm run clean:dist && npm run lint && tsc && npm run bundler:esbuild -- --minify=true",
     "build:dev": "npm run clean:dist && npm run lint && tsc && npm run bundler:esbuild",
     "build:test": "npm run build && npm run test",
+    "build:dev:test": "npm run build:dev && npm run test",
     "build:scratch": "npm install && npm run build:test"
   },
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@
 
 /*** CONSTANTS ***/
 const HASH: string = '#';
-const CLASSNAME: string = 'Klass';
+const CLASSNAME: string = 'Transmute';
 const EMPTY_STRING: string = '';
 const UNDERSCORE: string = '_';
 enum ERRORS {
@@ -31,9 +31,14 @@ export type GetterFn = () => unknown;
 
 export type GetterFnArray = () => unknown[];
 
+export type ValidatorFn = (value: unknown) => boolean | string;
+
 export type Config = {
     validateInput?: boolean;
     cloneable?: boolean;
+    rules?: {
+        [key: string]: ValidatorFn;
+    };
 };
 
 /*** UTILITY ***/
@@ -51,6 +56,37 @@ const getTypeOfObject = function (o: unknown) {
         .toLowerCase();
 };
 
+/* Validate rule for a property */
+const validateRule = function (nameSpace: string | undefined, key: string, value: unknown, validator?: ValidatorFn) {
+    if (config.rules != null) {
+        const nsKey = nameSpace != null && nameSpace.trim().length > 0 ? `${nameSpace}.${key}` : undefined;
+        validator = validator ?? (nsKey != null && config.rules[nsKey] != null ? config.rules[nsKey] : config.rules[key]);
+
+        const validate = (v: unknown, i?: number) => {
+            if (validator != null) {
+                const validationResponse = validator(v);
+                if (validationResponse !== true) {
+                    if (typeof validationResponse === 'string') {
+                        if (i != null) {
+                            throw new Error(`Validation error at index ${i} [${nsKey}]: ${validationResponse}`);
+                        }
+                        throw new Error(`Validation error [${nsKey}]: ${validationResponse}`);
+                    }
+                    throw new Error(`Validation failed for property ${nsKey} with value ${v}`);
+                }
+            }
+        };
+
+        if (validator != null && getTypeOfObject(validator) === 'function' && value != null) {
+            if (Array.isArray(value)) {
+                value.forEach(validate);
+                return;
+            }
+            validate(value);
+        }
+    }
+};
+
 const normalize = function (s: string) {
     if (!isNaN(Number(s[0]))) {
         s = '_' + s;
@@ -62,10 +98,15 @@ const capitalize = function (s: string) {
     return s[0].toUpperCase() + s.slice(1);
 };
 
+const generateStringFromArray = function (s: string[], joiner = ',', separator = ',', placeholder = ' COMMA_PLACEHOLDER'): string {
+    return s.join(joiner).replaceAll(separator, '').replaceAll(placeholder, ',');
+};
+
 // default configuration
 let config: Config = {
     validateInput: false,
-    cloneable: true
+    cloneable: true,
+    rules: {}
 };
 
 const setConfig = function (cfg: Config) {
@@ -88,41 +129,39 @@ export const memorySizeOf = function (obj: IStringIndex) {
 };
 
 /*** TRANSMUTE ***/
-const generateDynamicClassInstance = function (className: string, o: IStringIndex) {
+const generateDynamicClassInstance = function (className: string, o: IStringIndex, nameSpace = '') {
     const keys = Object.keys(o);
     const primitiveKeys = keys.filter((key) => getTypeOfObject(o[key]) !== 'object' && getTypeOfObject(o[key]) !== 'array');
     const objectKeys = keys.filter((key) => getTypeOfObject(o[key]) === 'object');
     const arrayKeys = keys.filter((key) => getTypeOfObject(o[key]) === 'array');
-    const privateProperties = keys
-        .map((key) => `${HASH}${normalize(key)};`)
-        .join(',')
-        .replaceAll(',', '');
+    const privateProperties = generateStringFromArray(keys.map((key) => `${HASH}${normalize(key)};`));
 
-    const accessorMethods = keys
-        .map((key) => {
+    const accessorMethods = generateStringFromArray(
+        keys.map((key) => {
             return `
               get${capitalize(normalize(key))}() {
                 return this.${HASH}${normalize(key)};
               }
-              set${capitalize(normalize(key))}(v) {
+              set${capitalize(normalize(key))}(v COMMA_PLACEHOLDER validator) {
+                this.utility.validateRule(this.getNameSpace() COMMA_PLACEHOLDER '${key}' COMMA_PLACEHOLDER v COMMA_PLACEHOLDER validator);
                 this.${HASH}${normalize(key)} = v;
                 return this;
               }
             `;
         })
-        .join(',')
-        .replaceAll(',', '');
+    );
 
-    const accessorMethodsWithValidation = keys
-        .map((key) => {
+    const accessorMethodsWithValidation = generateStringFromArray(
+        keys.map((key) => {
             const valueType = getTypeOfObject(o[key]);
             return `
               get${capitalize(normalize(key))}() {
                 return this.${HASH}${normalize(key)};
               }
-              set${capitalize(normalize(key))}(v) {
+              set${capitalize(normalize(key))}(v COMMA_PLACEHOLDER validator) {
                 const typeOfValue = this.utility.getTypeOfObject(v);
                 if (typeOfValue === '${valueType}') {
+                    this.utility.validateRule(this.getNameSpace() COMMA_PLACEHOLDER '${key}' COMMA_PLACEHOLDER v COMMA_PLACEHOLDER validator);
                     this.${HASH}${normalize(key)} = v;
                     return this;
                 }
@@ -130,11 +169,10 @@ const generateDynamicClassInstance = function (className: string, o: IStringInde
               }
             `;
         })
-        .join(',')
-        .replaceAll(',', '');
+    );
 
-    const indexedAccessorMethods = arrayKeys
-        .map((key) => {
+    const indexedAccessorMethods = generateStringFromArray(
+        arrayKeys.map((key) => {
             return `
               get${capitalize(normalize(key))}At(i) {
                 if (i != null) {
@@ -145,9 +183,10 @@ const generateDynamicClassInstance = function (className: string, o: IStringInde
                 }
                 throw 'Index should be of type number';
               }
-              set${capitalize(normalize(key))}At(i parameter_separator v) {
+              set${capitalize(normalize(key))}At(i COMMA_PLACEHOLDER v COMMA_PLACEHOLDER validator) {
                 if (Array.isArray(this.${HASH}${normalize(key)}) && i != null) {
                     if (i >= 0 && i < this.${HASH}${normalize(key)}.length) {
+                        this.utility.validateRule(this.getNameSpace() COMMA_PLACEHOLDER '${key}' COMMA_PLACEHOLDER v COMMA_PLACEHOLDER validator);
                         this.${HASH}${normalize(key)}[i] = v;
                         return this;
                     }
@@ -157,12 +196,10 @@ const generateDynamicClassInstance = function (className: string, o: IStringInde
               }
             `;
         })
-        .join(',')
-        .replaceAll(',', '')
-        .replaceAll('parameter_separator', ',');
+    );
 
-    const indexedAccessorMethodsWithValidation = arrayKeys
-        .map((key) => {
+    const indexedAccessorMethodsWithValidation = generateStringFromArray(
+        arrayKeys.map((key) => {
             return `
               get${capitalize(normalize(key))}At(i) {
                 const value = this.${HASH}${normalize(key)};
@@ -174,10 +211,11 @@ const generateDynamicClassInstance = function (className: string, o: IStringInde
                 }
                 throw 'Index should be of type number';
               }
-              set${capitalize(normalize(key))}At(i parameter_separator v) {
+              set${capitalize(normalize(key))}At(i COMMA_PLACEHOLDER v COMMA_PLACEHOLDER validator) {
                 const value = this.${HASH}${normalize(key)};
                 if (this.utility.getTypeOfObject(i) === 'number') {
                     if (i >= 0 && i < value.length) {
+                        this.utility.validateRule(this.getNameSpace() COMMA_PLACEHOLDER '${key}' COMMA_PLACEHOLDER v COMMA_PLACEHOLDER validator);
                         value[i] = v;
                         return this;
                     }
@@ -187,14 +225,21 @@ const generateDynamicClassInstance = function (className: string, o: IStringInde
               }
             `;
         })
-        .join(',')
-        .replaceAll(',', '')
-        .replaceAll('parameter_separator', ',');
+    );
 
     const dynamicClassDefinition = `
         return class ${capitalize(normalize(className))} {
           ${privateProperties}
+          #nameSpace = ${nameSpace.trim().length > 0 ? `'${nameSpace.trim()}'` : 'undefined'};
+
           constructor() {}
+
+          getNameSpace() {
+            if (this.#nameSpace != null) {
+                return this.#nameSpace.replace(/_/g, '.').trim();
+            }
+            return this.#nameSpace;
+          }
           ${config.validateInput ? accessorMethodsWithValidation : accessorMethods}
           ${config.validateInput ? indexedAccessorMethodsWithValidation : indexedAccessorMethods}
         }
@@ -242,7 +287,8 @@ const generateDynamicClassInstance = function (className: string, o: IStringInde
         };
         // Utility to check the type
         dynamicClass.prototype.utility = {
-            getTypeOfObject
+            getTypeOfObject,
+            validateRule
         };
     }
 
@@ -265,7 +311,13 @@ const generateDynamicClassInstance = function (className: string, o: IStringInde
     objectKeys.forEach((key: string): void => {
         const setAccessorMethod = `set${capitalize(normalize(key))}`;
         if (setAccessorMethod in instance && typeof instance[setAccessorMethod] === 'function') {
-            instance[setAccessorMethod](generateDynamicClassInstance(capitalize(normalize(key)), o[key] as IStringIndex));
+            instance[setAccessorMethod](
+                generateDynamicClassInstance(
+                    capitalize(normalize(key)),
+                    o[key] as IStringIndex,
+                    nameSpace.trim().length > 0 ? `${nameSpace}_${key}` : key
+                )
+            );
         }
     });
 
@@ -279,7 +331,11 @@ const generateDynamicClassInstance = function (className: string, o: IStringInde
             if (Array.isArray(values)) {
                 const valueInstances = values.map((value, index) => {
                     if (getTypeOfObject(value) === 'object') {
-                        return generateDynamicClassInstance(capitalize(normalize(`${key}${index}`)), value as IStringIndex);
+                        return generateDynamicClassInstance(
+                            capitalize(normalize(`${key}${index}`)),
+                            value as IStringIndex,
+                            nameSpace.trim().length > 0 ? `${nameSpace}_${key}` : key
+                        );
                     }
                     if (getTypeOfObject(value) === 'array') {
                         throw 'Multidimensional array not supported. Yet!';

--- a/test/rules.test.js
+++ b/test/rules.test.js
@@ -1,0 +1,218 @@
+import { describe, expect, test } from '@jest/globals';
+import { transmute } from '../dist/index.js';
+
+const data = {
+    company: 'TechCorp',
+    info: {
+        location: 'Hyderabad',
+        office: 'Ascendas IT Park',
+        floor: 9,
+        contacts: ['+91-040-123-4567', '+91-040-123-4568', '+91-040-123-4569', '+91-040-123-4570'],
+        hybrid: true
+    },
+    departments: [
+        {
+            name: 'Engineering',
+            manager: {
+                id: 'E-10001',
+                name: 'Alpha',
+                email: 'alpha@techcorp.com',
+                contact: '+91-123-456-7890',
+                role: 'Engineering Manager',
+                skills: ['JavaScript', 'Architecture']
+            },
+            employees: [
+                {
+                    id: 'E-10002',
+                    name: 'Beta',
+                    email: 'beta@techcorp.com',
+                    contact: '+91-23145-67890',
+                    role: 'Senior Developer',
+                    projects: [
+                        {
+                            id: 'P-3000',
+                            name: 'Project 3000',
+                            status: 'Completed'
+                        },
+                        {
+                            id: 'P-9000',
+                            name: 'Project 9000',
+                            status: 'Active'
+                        }
+                    ]
+                },
+                {
+                    id: 'E-10003',
+                    name: 'Gamma',
+                    email: 'gamma@techcorp.com',
+                    contact: '+91 32145 67890',
+                    role: 'DevOps',
+                    projects: [
+                        {
+                            id: 'P-1000',
+                            name: 'Project 1000',
+                            status: 'Completed'
+                        },
+                        {
+                            id: 'P-3000',
+                            name: 'Project 3000',
+                            status: 'Completed'
+                        },
+                        {
+                            id: 'P-9000',
+                            name: 'Project 9000',
+                            status: 'Active'
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            name: 'HR',
+            employees: [
+                {
+                    id: 'E-10000',
+                    name: 'Delta',
+                    email: 'delta@techcorp.com',
+                    contact: '+91 32145 67890',
+                    role: 'Technical Recruiter'
+                }
+            ]
+        }
+    ]
+};
+
+const contactsPattern1 = /^[+]?\d{1,3}[-\s]?\d{3}[-\s]?\d{3}[-\s]?\d{4}$/;
+const projectStatuses = ['Not started', 'Active', 'On hold', 'Completed'];
+
+describe('Custom validations via rules', () => {
+    let o = null;
+    try {
+        o = transmute(data, {
+            validateInput: true,
+            rules: {
+                id: (value) => value.startsWith('E-') || 'Employee ID should start with E-',
+                email: (value) => /^\S+@\S+\.\S+$/.test(value) || 'Invalid email format',
+                contact: (value) =>
+                    /^[+]?\d{1,3}[-\s]?\d{5}[-\s]?\d{5}$/.test(value) ||
+                    'Invalid contact number, expected format: +xx-xxxxx-xxxxx or +xx xxxxx xxxxx',
+                info: (value) => {
+                    if (typeof value !== 'object' || value === null) {
+                        return 'Info should be an object';
+                    }
+                    const valueJson = typeof value.toJson === 'function' ? value.toJson() : value;
+                    if (!('contacts' in valueJson)) {
+                        return 'Info should have a contacts property';
+                    }
+                    return true;
+                },
+                'info.contacts': (value) =>
+                    contactsPattern1.test(value) || 'Invalid contact number, expected format: +xx-xxx-xxx-xxxx or +xx xxx xxx xxxx',
+                'departments.manager.contact': (value) =>
+                    contactsPattern1.test(value) || 'Invalid contact number, expected format: +xx-xxx-xxx-xxxx or +xx xxx xxx xxxx',
+                'departments.employees.projects.id': (value) => value.startsWith('P-') || 'Project ID should start with P-',
+                'departments.employees.projects.status': (value) => projectStatuses.includes(value) || 'Invalid project status'
+            }
+        });
+    } catch (e) {
+        console.error('Error during transmutation:', e);
+    }
+
+    test('Check setter validation errors for string input', () => {
+        expect(() => o.setCompany()).toThrowError('Type mismatch: argument of type string expected but got undefined instead');
+        expect(() => o.setCompany(123)).toThrowError('Type mismatch: argument of type string expected but got number instead');
+        expect(() => o.setCompany(true)).toThrowError('Type mismatch: argument of type string expected but got boolean instead');
+        expect(() => o.setCompany([])).toThrowError('Type mismatch: argument of type string expected but got array instead');
+        expect(() => o.setCompany({})).toThrowError('Type mismatch: argument of type string expected but got object instead');
+        expect(() => o.setCompany(null)).toThrowError('Type mismatch: argument of type string expected but got null instead');
+    });
+
+    test('Check setter validation errors for number input', () => {
+        const info = o.getInfo();
+        expect(() => info.setFloor()).toThrowError('Type mismatch: argument of type number expected but got undefined instead');
+        expect(() => info.setFloor('')).toThrowError('Type mismatch: argument of type number expected but got string instead');
+        expect(() => info.setFloor(true)).toThrowError('Type mismatch: argument of type number expected but got boolean instead');
+        expect(() => info.setFloor([])).toThrowError('Type mismatch: argument of type number expected but got array instead');
+        expect(() => info.setFloor({})).toThrowError('Type mismatch: argument of type number expected but got object instead');
+        expect(() => info.setFloor(null)).toThrowError('Type mismatch: argument of type number expected but got null instead');
+    });
+
+    test('Check setter validation errors for boolean input', () => {
+        const info = o.getInfo();
+        expect(() => info.setHybrid()).toThrowError('Type mismatch: argument of type boolean expected but got undefined instead');
+        expect(() => info.setHybrid('')).toThrowError('Type mismatch: argument of type boolean expected but got string instead');
+        expect(() => info.setHybrid(123)).toThrowError('Type mismatch: argument of type boolean expected but got number instead');
+        expect(() => info.setHybrid([])).toThrowError('Type mismatch: argument of type boolean expected but got array instead');
+        expect(() => info.setHybrid({})).toThrowError('Type mismatch: argument of type boolean expected but got object instead');
+        expect(() => info.setHybrid(null)).toThrowError('Type mismatch: argument of type boolean expected but got null instead');
+    });
+
+    test('Check setter validation errors for array input', () => {
+        expect(() => o.setDepartments()).toThrowError('Type mismatch: argument of type array expected but got undefined instead');
+        expect(() => o.setDepartments('')).toThrowError('Type mismatch: argument of type array expected but got string instead');
+        expect(() => o.setDepartments(123)).toThrowError('Type mismatch: argument of type array expected but got number instead');
+        expect(() => o.setDepartments(false)).toThrowError('Type mismatch: argument of type array expected but got boolean instead');
+        expect(() => o.setDepartments({})).toThrowError('Type mismatch: argument of type array expected but got object instead');
+        expect(() => o.setDepartments(null)).toThrowError('Type mismatch: argument of type array expected but got null instead');
+    });
+
+    test('Check setter validation errors for object input', () => {
+        expect(() => o.setInfo()).toThrowError('Type mismatch: argument of type object expected but got undefined instead');
+        expect(() => o.setInfo('')).toThrowError('Type mismatch: argument of type object expected but got string instead');
+        expect(() => o.setInfo(123)).toThrowError('Type mismatch: argument of type object expected but got number instead');
+        expect(() => o.setInfo(false)).toThrowError('Type mismatch: argument of type object expected but got boolean instead');
+        expect(() => o.setInfo([])).toThrowError('Type mismatch: argument of type object expected but got array instead');
+        expect(() => o.setInfo(null)).toThrowError('Type mismatch: argument of type object expected but got null instead');
+    });
+
+    test('Check indexed setter validation errors for array input', () => {
+        expect(() => o.setDepartmentsAt()).toThrowError('Index should be of type number');
+        expect(() => o.setDepartmentsAt(-1)).toThrowError('Index out of bound!');
+        expect(() => o.setDepartmentsAt(3)).toThrowError('Index out of bound!');
+    });
+
+    test('Check validation rules', () => {
+        const manager = o.getDepartmentsAt(0).getManager();
+        expect(() => manager.setId('10001')).toThrowError('Employee ID should start with E-');
+        expect(() => manager.setEmail('alpha@techcorp')).toThrowError('Invalid email format');
+        expect(() => manager.setContact('1234567890')).toThrowError(
+            'Invalid contact number, expected format: +xx-xxx-xxx-xxxx or +xx xxx xxx xxxx'
+        );
+
+        expect(() => o.setInfo()).toThrowError('Type mismatch: argument of type object expected but got undefined instead');
+        expect(() => o.setInfo([])).toThrowError('Type mismatch: argument of type object expected but got array instead');
+        expect(() =>
+            o.setInfo({
+                location: 'Hyderabad',
+                office: 'Ascendas IT Park',
+                floor: 9
+            })
+        ).toThrowError('Info should have a contacts property');
+
+        const info = o.getInfo();
+        expect(() => info.setContacts('+91-040-123-456')).toThrowError(
+            'Type mismatch: argument of type array expected but got string instead'
+        );
+        expect(() => info.setContactsAt(0, '+91-040-123-456')).toThrowError(
+            'Invalid contact number, expected format: +xx-xxx-xxx-xxxx or +xx xxx xxx xxxx'
+        );
+
+        const p0 = o.getDepartmentsAt(0).getEmployeesAt(0).getProjectsAt(0);
+        expect(() => p0.setId('1000')).toThrowError('Project ID should start with P-');
+        expect(() => p0.setStatus('Finished')).toThrowError('Invalid project status');
+    });
+
+    test('Check custom validation rules', () => {
+        expect(() =>
+            o
+                .getInfo()
+                .setContactsAt(
+                    0,
+                    '+91-040-123-4567',
+                    (value) =>
+                        /^[+]?\d{1,3}[-\s]?\d{5}[-\s]?\d{5}$/.test(value) ||
+                        'Invalid contact number, expected format: +xx-xxxxx-xxxxx or +xx xxxxx xxxxx'
+                )
+        ).toThrowError('Invalid contact number, expected format: +xx-xxxxx-xxxxx or +xx xxxxx xxxxx');
+    });
+});


### PR DESCRIPTION
### Description

Updated the library to support rules validation
- Added optional rules property to the `Config` type
- Added namespace for the nested object structure
- Exposed a `getNameSpace` accessor method for each dynamically generated Class
- Logic to validate rules based on namespaced property or to pick up a base validation rule
- Evaluating the rules on Transmute Object creation
- Evaluating the rules on setting a value via set accessor method
- Added possibility to provide a custom validation function to the set accessor method
- Added test cases for rules validations
- Code clean-up and refactoring
 
Fixes: #16 