### PR TITLE
fix(18): Namespace set to undefined for first level properties

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,7 @@ export const memorySizeOf = function (obj: IStringIndex) {
 };
 
 /*** TRANSMUTE ***/
-const generateDynamicClassInstance = function (className: string, o: IStringIndex, nameSpace = '') {
+const generateDynamicClassInstance = function (className: string, o: IStringIndex, nameSpace = 'root') {
     const keys = Object.keys(o);
     const primitiveKeys = keys.filter((key) => getTypeOfObject(o[key]) !== 'object' && getTypeOfObject(o[key]) !== 'array');
     const objectKeys = keys.filter((key) => getTypeOfObject(o[key]) === 'object');

--- a/test/rules.test.js
+++ b/test/rules.test.js
@@ -106,12 +106,12 @@ describe('Custom validations via rules', () => {
                     }
                     return true;
                 },
-                'info.contacts': (value) =>
+                'root.info.contacts': (value) =>
                     contactsPattern1.test(value) || 'Invalid contact number, expected format: +xx-xxx-xxx-xxxx or +xx xxx xxx xxxx',
-                'departments.manager.contact': (value) =>
+                'root.departments.manager.contact': (value) =>
                     contactsPattern1.test(value) || 'Invalid contact number, expected format: +xx-xxx-xxx-xxxx or +xx xxx xxx xxxx',
-                'departments.employees.projects.id': (value) => value.startsWith('P-') || 'Project ID should start with P-',
-                'departments.employees.projects.status': (value) => projectStatuses.includes(value) || 'Invalid project status'
+                'root.departments.employees.projects.id': (value) => value.startsWith('P-') || 'Project ID should start with P-',
+                'root.departments.employees.projects.status': (value) => projectStatuses.includes(value) || 'Invalid project status'
             }
         });
     } catch (e) {


### PR DESCRIPTION
### Description:

Setting root as the namespace for first level properties
- Updated test cases accordingly

Fixes: #18 