### PR TITLE
feat(context-aware validation): For cross-property and object-graph rules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,34 @@ export type GetterFn = () => unknown;
 
 export type GetterFnArray = () => unknown[];
 
-export type ValidatorFn = (value: unknown) => boolean | string;
+export type ValidatorContext = {
+    key: string; // Property name (e.g., "password")
+    path: string; // Full namespaced path (e.g., "root.account.password")
+    value: unknown; // The value being validated
+    parentObject?: unknown; // The immediate parent object
+    rootObject?: unknown; // The root transmuted object
+    index?: number; // Array index if validating array element
+    getParent: () => unknown; // Function to safely access parent
+    getRoot: () => unknown; // Function to safely access root
+};
+
+export type ValidatorFn = (value: unknown, context: ValidatorContext) => boolean | string;
+
+type DynamicClassInstance = IStringIndex & {
+    setInternalReferences: (root: unknown, parent: unknown, index?: number) => unknown;
+    toJson: () => IStringIndex;
+    clone: () => IStringIndex;
+    getMetaInfo: () => MetaInfo;
+    utility: {
+        getTypeOfObject: typeof getTypeOfObject;
+        validateRule: typeof validateRule;
+    };
+};
+
+type DynamicClassConstructor = {
+    new (): DynamicClassInstance;
+    prototype: IStringIndex;
+};
 
 export type Config = {
     validateInput?: boolean;
@@ -57,29 +84,61 @@ const getTypeOfObject = function (o: unknown) {
 };
 
 /* Validate rule for a property */
-const validateRule = function (nameSpace: string | undefined, key: string, value: unknown, validator?: ValidatorFn) {
+const validateRule = function (
+    nameSpace: string | undefined,
+    key: string,
+    value: unknown,
+    validator?: ValidatorFn,
+    parentObject?: unknown,
+    rootObject?: unknown,
+    index?: number
+) {
     if (config.rules != null) {
         const nsKey = nameSpace != null && nameSpace.trim().length > 0 ? `${nameSpace}.${key}` : undefined;
-        validator = validator ?? (nsKey != null && config.rules[nsKey] != null ? config.rules[nsKey] : config.rules[key]);
+
+        let usedKey = key;
+        const contextPath = nameSpace === 'root' ? key : (nsKey ?? key);
+        if (nsKey != null && config.rules[nsKey] != null) {
+            validator = validator ?? config.rules[nsKey];
+            usedKey = nsKey;
+        } else if (config.rules && config.rules[key] != null) {
+            validator = validator ?? config.rules[key];
+            usedKey = key;
+        }
 
         const validate = (v: unknown, i?: number) => {
             if (validator != null) {
-                const validationResponse = validator(v);
+                const finalIndex = i ?? index ?? (parentObject as { getIndex?: () => number })?.getIndex?.();
+                // Pass the value together with its location and object-graph references
+                // so validators can enforce rules involving sibling, parent, root, or array data.
+                const context: ValidatorContext = {
+                    key,
+                    path: contextPath,
+                    value: v,
+                    parentObject,
+                    rootObject,
+                    index: finalIndex,
+                    getParent: () => parentObject,
+                    getRoot: () => rootObject
+                };
+                const validationResponse = validator(v, context);
+
                 if (validationResponse !== true) {
                     if (typeof validationResponse === 'string') {
-                        if (i != null) {
-                            throw new Error(`Validation error at index ${i} [${nsKey}]: ${validationResponse}`);
+                        const errorIndex = i ?? index ?? (parentObject as { getIndex?: () => number })?.getIndex?.();
+                        if (errorIndex != null) {
+                            throw new Error(`Validation error at index ${errorIndex} [${usedKey}]: ${validationResponse}`);
                         }
-                        throw new Error(`Validation error [${nsKey}]: ${validationResponse}`);
+                        throw new Error(`Validation error [${usedKey}]: ${validationResponse}`);
                     }
-                    throw new Error(`Validation failed for property ${nsKey} with value ${v}`);
+                    throw new Error(`Validation failed for property ${usedKey} with value ${v}`);
                 }
             }
         };
 
         if (validator != null && getTypeOfObject(validator) === 'function' && value != null) {
             if (Array.isArray(value)) {
-                value.forEach(validate);
+                value.forEach((v, idx) => validate(v, idx));
                 return;
             }
             validate(value);
@@ -129,12 +188,29 @@ export const memorySizeOf = function (obj: IStringIndex) {
 };
 
 /*** TRANSMUTE ***/
-const generateDynamicClassInstance = function (className: string, o: IStringIndex, nameSpace = 'root') {
+const generateDynamicClassInstance = function (
+    className: string,
+    o: IStringIndex,
+    nameSpace = 'root',
+    root?: unknown,
+    parent?: unknown,
+    index?: number
+) {
     const keys = Object.keys(o);
     const primitiveKeys = keys.filter((key) => getTypeOfObject(o[key]) !== 'object' && getTypeOfObject(o[key]) !== 'array');
     const objectKeys = keys.filter((key) => getTypeOfObject(o[key]) === 'object');
     const arrayKeys = keys.filter((key) => getTypeOfObject(o[key]) === 'array');
     const privateProperties = generateStringFromArray(keys.map((key) => `${HASH}${normalize(key)};`));
+    const initializationMethods = generateStringFromArray(
+        keys.map((key) => {
+            return `
+                            initialize${capitalize(normalize(key))}(v) {
+                                this.${HASH}${normalize(key)} = v;
+                                return this;
+                            }
+                        `;
+        })
+    );
 
     const accessorMethods = generateStringFromArray(
         keys.map((key) => {
@@ -143,7 +219,14 @@ const generateDynamicClassInstance = function (className: string, o: IStringInde
                 return this.${HASH}${normalize(key)};
               }
               set${capitalize(normalize(key))}(v COMMA_PLACEHOLDER validator) {
-                this.utility.validateRule(this.getNameSpace() COMMA_PLACEHOLDER '${key}' COMMA_PLACEHOLDER v COMMA_PLACEHOLDER validator);
+                this.utility.validateRule(
+                  this.getNameSpace() COMMA_PLACEHOLDER 
+                  '${key}' COMMA_PLACEHOLDER 
+                  v COMMA_PLACEHOLDER 
+                  validator COMMA_PLACEHOLDER
+                  this COMMA_PLACEHOLDER
+                  this.getRoot()
+                );
                 this.${HASH}${normalize(key)} = v;
                 return this;
               }
@@ -161,7 +244,14 @@ const generateDynamicClassInstance = function (className: string, o: IStringInde
               set${capitalize(normalize(key))}(v COMMA_PLACEHOLDER validator) {
                 const typeOfValue = this.utility.getTypeOfObject(v);
                 if (typeOfValue === '${valueType}') {
-                    this.utility.validateRule(this.getNameSpace() COMMA_PLACEHOLDER '${key}' COMMA_PLACEHOLDER v COMMA_PLACEHOLDER validator);
+                    this.utility.validateRule(
+                      this.getNameSpace() COMMA_PLACEHOLDER 
+                      '${key}' COMMA_PLACEHOLDER 
+                      v COMMA_PLACEHOLDER 
+                      validator COMMA_PLACEHOLDER
+                      this COMMA_PLACEHOLDER
+                      this.getRoot()
+                    );
                     this.${HASH}${normalize(key)} = v;
                     return this;
                 }
@@ -186,7 +276,15 @@ const generateDynamicClassInstance = function (className: string, o: IStringInde
               set${capitalize(normalize(key))}At(i COMMA_PLACEHOLDER v COMMA_PLACEHOLDER validator) {
                 if (Array.isArray(this.${HASH}${normalize(key)}) && i != null) {
                     if (i >= 0 && i < this.${HASH}${normalize(key)}.length) {
-                        this.utility.validateRule(this.getNameSpace() COMMA_PLACEHOLDER '${key}' COMMA_PLACEHOLDER v COMMA_PLACEHOLDER validator);
+                        this.utility.validateRule(
+                          this.getNameSpace() COMMA_PLACEHOLDER 
+                          '${key}' COMMA_PLACEHOLDER 
+                          v COMMA_PLACEHOLDER 
+                          validator COMMA_PLACEHOLDER
+                          this COMMA_PLACEHOLDER
+                          this.getRoot() COMMA_PLACEHOLDER
+                          i
+                        );
                         this.${HASH}${normalize(key)}[i] = v;
                         return this;
                     }
@@ -215,7 +313,15 @@ const generateDynamicClassInstance = function (className: string, o: IStringInde
                 const value = this.${HASH}${normalize(key)};
                 if (this.utility.getTypeOfObject(i) === 'number') {
                     if (i >= 0 && i < value.length) {
-                        this.utility.validateRule(this.getNameSpace() COMMA_PLACEHOLDER '${key}' COMMA_PLACEHOLDER v COMMA_PLACEHOLDER validator);
+                        this.utility.validateRule(
+                          this.getNameSpace() COMMA_PLACEHOLDER 
+                          '${key}' COMMA_PLACEHOLDER 
+                          v COMMA_PLACEHOLDER 
+                          validator COMMA_PLACEHOLDER
+                          this COMMA_PLACEHOLDER
+                          this.getRoot() COMMA_PLACEHOLDER
+                          i
+                        );
                         value[i] = v;
                         return this;
                     }
@@ -231,6 +337,9 @@ const generateDynamicClassInstance = function (className: string, o: IStringInde
         return class ${capitalize(normalize(className))} {
           ${privateProperties}
           #nameSpace = ${nameSpace.trim().length > 0 ? `'${nameSpace.trim()}'` : 'undefined'};
+          #root = undefined;
+          #parent = undefined;
+          #index = undefined;
 
           constructor() {}
 
@@ -240,18 +349,36 @@ const generateDynamicClassInstance = function (className: string, o: IStringInde
             }
             return this.#nameSpace;
           }
+
+          setInternalReferences(root, parent, index) {
+            this.#root = root;
+            this.#parent = parent;
+            this.#index = index;
+            return this;
+          }
+
+          getParent() {
+            return this.#parent;
+          }
+
+          getRoot() {
+            return this.#root;
+          }
+
+          getIndex() {
+            return this.#index;
+          }
+
+          ${initializationMethods}
+
           ${config.validateInput ? accessorMethodsWithValidation : accessorMethods}
           ${config.validateInput ? indexedAccessorMethodsWithValidation : indexedAccessorMethods}
         }
       `;
 
     // This will generate an anonymous iife that returns a Class
-    const dynamicClassWrapper = new Function('', dynamicClassDefinition);
-
-    // TODO: Figure out a way to get rid of this error
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    const dynamicClass = new dynamicClassWrapper();
+    const dynamicClassFactory = new Function('', dynamicClassDefinition) as unknown as () => DynamicClassConstructor;
+    const dynamicClass = dynamicClassFactory();
 
     // Attach utility methods to the prototype of the Class
     if (dynamicClass.prototype != null) {
@@ -266,7 +393,7 @@ const generateDynamicClassInstance = function (className: string, o: IStringInde
         // Config driven
         if (config.cloneable) {
             // Create a clone of the transmuted object
-            dynamicClass.prototype.clone = function () {
+            dynamicClass.prototype.clone = function (this: DynamicClassInstance) {
                 return transmute(this.toJson());
             };
         }
@@ -294,55 +421,67 @@ const generateDynamicClassInstance = function (className: string, o: IStringInde
 
     const instance = new dynamicClass();
 
-    /** --- Calling set accessor methods on the instance to initialize the private properties --- **/
-    // iterate over the primitive keys
-    // if we find an object then we generate a dynamic class and assign its value
-    // else, we directly set the value the property returns
+    // Store navigation metadata on every generated instance. The root reference
+    // enables access to the full object graph, the parent reference enables
+    // sibling/parent lookups, and the index identifies array elements in validator context.
+    const rootObj = root || instance;
+    const parentObj = parent || instance;
+    instance.setInternalReferences(rootObj, parentObj, index);
+
+    /** --- Initialize private properties without invoking public validation setters --- **/
+    // Initialize primitive values directly through the generated internal method.
+    // This construction path bypasses public setters so validation is reserved for updates.
     primitiveKeys.forEach((key: string): void => {
-        const setAccessorMethod = `set${capitalize(normalize(key))}`;
-        if (setAccessorMethod in instance && typeof instance[setAccessorMethod] === 'function') {
-            instance[setAccessorMethod](o[key]);
+        const initializeAccessorMethod = `initialize${capitalize(normalize(key))}`;
+        if (initializeAccessorMethod in instance && typeof instance[initializeAccessorMethod] === 'function') {
+            instance[initializeAccessorMethod](o[key]);
         }
     });
 
-    // iterate over the object type keys
-    // if we find an object then we generate a dynamic class and assign its value
-    // else, we directly set the value the property returns
+    // Recursively generate nested objects with their root, parent, and index metadata,
+    // then assign each child through its internal initializer without triggering validation.
     objectKeys.forEach((key: string): void => {
-        const setAccessorMethod = `set${capitalize(normalize(key))}`;
-        if (setAccessorMethod in instance && typeof instance[setAccessorMethod] === 'function') {
-            instance[setAccessorMethod](
-                generateDynamicClassInstance(
-                    capitalize(normalize(key)),
-                    o[key] as IStringIndex,
-                    nameSpace.trim().length > 0 ? `${nameSpace}_${key}` : key
-                )
+        const initializeAccessorMethod = `initialize${capitalize(normalize(key))}`;
+        if (initializeAccessorMethod in instance && typeof instance[initializeAccessorMethod] === 'function') {
+            const nestedInstance = generateDynamicClassInstance(
+                capitalize(normalize(key)),
+                o[key] as IStringIndex,
+                nameSpace.trim().length > 0 ? `${nameSpace}_${key}` : key,
+                rootObj,
+                instance
             );
+            instance[initializeAccessorMethod](nestedInstance);
         }
     });
 
-    // iterate over the array type keys
-    // we map through our array and if we find an object then we generate a dynamic class and assign its value
-    // else, we simply return the value
+    // Build arrays by recursively generating object elements while preserving primitive values,
+    // then assign the completed array through the internal initializer.
     arrayKeys.forEach((key: string): void => {
-        const setAccessorMethod = `set${capitalize(normalize(key))}`;
-        if (setAccessorMethod in instance && typeof instance[setAccessorMethod] === 'function') {
+        const initializeAccessorMethod = `initialize${capitalize(normalize(key))}`;
+        if (initializeAccessorMethod in instance && typeof instance[initializeAccessorMethod] === 'function') {
             const values = o[key];
             if (Array.isArray(values)) {
-                const valueInstances = values.map((value, index) => {
+                if (values.some((value) => getTypeOfObject(value) === 'object')) {
+                    instance[initializeAccessorMethod]([]);
+                }
+                const valueInstances = values.map((value, idx) => {
                     if (getTypeOfObject(value) === 'object') {
-                        return generateDynamicClassInstance(
-                            capitalize(normalize(`${key}${index}`)),
+                        const nestedInstance = generateDynamicClassInstance(
+                            capitalize(normalize(`${key}${idx}`)),
                             value as IStringIndex,
-                            nameSpace.trim().length > 0 ? `${nameSpace}_${key}` : key
+                            nameSpace.trim().length > 0 ? `${nameSpace}_${key}` : key,
+                            rootObj,
+                            instance,
+                            idx
                         );
+                        return nestedInstance;
                     }
                     if (getTypeOfObject(value) === 'array') {
                         throw 'Multidimensional array not supported. Yet!';
                     }
                     return value;
                 });
-                instance[setAccessorMethod](valueInstances);
+                instance[initializeAccessorMethod](valueInstances);
             }
         }
     });
@@ -358,7 +497,11 @@ export function transmute(o: IStringIndex, config?: Config, className?: string):
         setConfig(config);
     }
     // return the transmuted JSON with private properties and accessor methods
-    return generateDynamicClassInstance(capitalize(normalize(className ?? `${CLASSNAME}${randomNumber()}`)), o);
+    const instance = generateDynamicClassInstance(capitalize(normalize(className ?? `${CLASSNAME}${randomNumber()}`)), o);
+    // Keep the root instance as its own root reference so every nested model can
+    // access the complete transmuted object graph through ValidatorContext.getRoot().
+    instance.setInternalReferences(instance, instance, undefined);
+    return instance;
 }
 
 /*** UNTRANSMUTE ***/

--- a/test/configuration-state.test.js
+++ b/test/configuration-state.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, test } from '@jest/globals';
+import { transmute } from '../dist/index.js';
+
+describe('Configuration and model state', () => {
+    test('cloneable false removes clone while preserving serialization', () => {
+        const user = transmute(
+            { name: 'Jane' },
+            {
+                cloneable: false
+            }
+        );
+
+        expect(user.clone).toBeUndefined();
+        expect(user.toJson()).toEqual({ name: 'Jane' });
+    });
+
+    test('explicit configuration can restore clone support', () => {
+        transmute({ name: 'Without clone' }, { cloneable: false });
+        const user = transmute({ name: 'With clone' }, { cloneable: true });
+
+        expect(user.clone).toBeDefined();
+        expect(user.clone().toJson()).toEqual({ name: 'With clone' });
+    });
+
+    test('validation remains enabled for models configured with validateInput', () => {
+        const user = transmute(
+            { age: 30 },
+            {
+                validateInput: true,
+                rules: {
+                    age: (value) => value >= 18 || 'Must be an adult'
+                }
+            }
+        );
+
+        expect(() => user.setAge(15)).toThrowError('Must be an adult');
+        expect(user.getAge()).toBe(30);
+    });
+
+    test('models retain their generated API after later transmute calls', () => {
+        const first = transmute({ name: 'First' }, { cloneable: true });
+        transmute({ name: 'Second' }, { cloneable: false });
+
+        expect(first.getName()).toBe('First');
+        expect(first.toJson()).toEqual({ name: 'First' });
+        expect(first.clone).toBeDefined();
+    });
+});

--- a/test/context-aware-arrays.test.js
+++ b/test/context-aware-arrays.test.js
@@ -1,0 +1,50 @@
+import { describe, expect, test } from '@jest/globals';
+import { transmute } from '../dist/index.js';
+
+describe('Context-aware arrays', () => {
+    test('supports positional validation using array indexes', () => {
+        const o = transmute(
+            { contacts: ['primary', 'secondary', 'tertiary'] },
+            {
+                validateInput: true,
+                rules: {
+                    contacts: (value, context) => {
+                        if (context.index === 0 && value !== 'primary') {
+                            return 'First contact must be marked as primary';
+                        }
+                        return true;
+                    }
+                }
+            }
+        );
+
+        expect(() => o.setContactsAt(0, 'primary')).not.toThrow();
+        expect(() => o.setContactsAt(0, 'secondary')).toThrowError('First contact must be marked as primary');
+        expect(() => o.setContactsAt(1, 'secondary')).not.toThrow();
+    });
+
+    test('enforces uniqueness using the array index', () => {
+        const o = transmute(
+            {
+                employees: [
+                    { id: 'E-1001', name: 'Alice' },
+                    { id: 'E-1002', name: 'Bob' }
+                ]
+            },
+            {
+                validateInput: true,
+                rules: {
+                    'root.employees.id': (value, context) => {
+                        const ids = context.rootObject
+                            .getEmployees()
+                            .map((employee, index) => (index === context.index ? value : employee.getId()));
+                        return new Set(ids).size === ids.length || `Duplicate ID: ${value}`;
+                    }
+                }
+            }
+        );
+
+        expect(() => o.getEmployeesAt(1).setId('E-1003')).not.toThrow();
+        expect(() => o.getEmployeesAt(1).setId('E-1001')).toThrowError(/Duplicate ID/);
+    });
+});

--- a/test/context-aware-business.test.js
+++ b/test/context-aware-business.test.js
@@ -1,0 +1,139 @@
+import { describe, expect, test } from '@jest/globals';
+import { transmute } from '../dist/index.js';
+
+describe('Context-aware business rules', () => {
+    test('validates password confirmation using a sibling property', () => {
+        const o = transmute(
+            { password: 'secret123', confirmPassword: 'secret123' },
+            {
+                validateInput: true,
+                rules: {
+                    confirmPassword: (value, context) => {
+                        const password = context.parentObject.getPassword();
+                        return password === value || 'Passwords do not match';
+                    }
+                }
+            }
+        );
+
+        expect(() => o.setConfirmPassword('secret123')).not.toThrow();
+        expect(() => o.setConfirmPassword('wrong')).toThrowError('Passwords do not match');
+    });
+
+    test('validates date ranges using a sibling property', () => {
+        const o = transmute(
+            { startDate: new Date('2024-01-01'), endDate: new Date('2024-12-31') },
+            {
+                validateInput: true,
+                rules: {
+                    endDate: (value, context) => {
+                        const startDate = context.parentObject.getStartDate();
+                        return value >= startDate || 'End date must be after start date';
+                    }
+                }
+            }
+        );
+
+        expect(() => o.setEndDate(new Date('2025-01-01'))).not.toThrow();
+        expect(() => o.setEndDate(new Date('2023-01-01'))).toThrowError('End date must be after start date');
+    });
+
+    test('validates a nested field using a sibling property', () => {
+        const o = transmute(
+            { info: { country: 'US', phone: '+1-123-456-7890' } },
+            {
+                validateInput: true,
+                rules: {
+                    'root.info.phone': (value, context) => {
+                        if (context.parentObject.getCountry() === 'US') {
+                            return /^\+1-\d{3}-\d{3}-\d{4}$/.test(value) || 'Invalid US phone format';
+                        }
+                        return true;
+                    }
+                }
+            }
+        );
+
+        expect(() => o.getInfo().setPhone('+1-999-888-7777')).not.toThrow();
+        expect(() => o.getInfo().setPhone('invalid')).toThrowError('Invalid US phone format');
+    });
+
+    test('prevents archiving a department with active projects', () => {
+        const data = {
+            departments: [
+                {
+                    name: 'Engineering',
+                    status: 'active',
+                    employees: [{ id: 'E-1001', name: 'Alice', projects: [{ id: 'P-1', status: 'Active' }] }]
+                }
+            ]
+        };
+
+        const o = transmute(data, {
+            validateInput: true,
+            rules: {
+                'root.departments.status': (value, context) => {
+                    if (value === 'archived') {
+                        const employees = context.parentObject.getEmployees();
+                        const hasActiveProjects = employees.some((employee) =>
+                            employee.getProjects().some((project) => project.getStatus() === 'Active')
+                        );
+                        return !hasActiveProjects || 'Cannot archive department with active projects';
+                    }
+                    return true;
+                }
+            }
+        });
+
+        expect(() => o.getDepartmentsAt(0).setStatus('archived')).toThrowError('Cannot archive department with active projects');
+        expect(() => o.getDepartmentsAt(0).setStatus('inactive')).not.toThrow();
+    });
+
+    test('enforces a company-wide department budget limit', () => {
+        const data = {
+            company: { totalBudget: 1000000 },
+            departments: [
+                { name: 'Engineering', budget: 500000 },
+                { name: 'HR', budget: 200000 }
+            ]
+        };
+
+        const o = transmute(data, {
+            validateInput: true,
+            rules: {
+                'root.departments.budget': (value, context) => {
+                    const totalBudget = context.rootObject.getCompany().getTotalBudget();
+                    const otherBudget = context.rootObject
+                        .getDepartments()
+                        .reduce((sum, department) => (department === context.parentObject ? sum : sum + department.getBudget()), 0);
+                    const totalNeeded = otherBudget + value;
+                    return totalNeeded <= totalBudget || `Total budget would exceed limit. Max: ${totalBudget}, Requested: ${totalNeeded}`;
+                }
+            }
+        });
+
+        expect(() => o.getDepartmentsAt(0).setBudget(900000)).toThrowError(/Total budget would exceed limit/);
+        expect(() => o.getDepartmentsAt(0).setBudget(300000)).not.toThrow();
+    });
+
+    test('requires a lead before setting a team budget', () => {
+        const data = {
+            org: {
+                name: 'TechCorp',
+                divisions: [{ name: 'Product', teams: [{ name: 'Backend', budget: 500000, members: [{ id: 'E-1', role: 'lead' }] }] }]
+            }
+        };
+
+        const o = transmute(data, {
+            validateInput: true,
+            rules: {
+                'root.org.divisions.teams.budget': (value, context) => {
+                    const hasLead = context.parentObject.getMembers().some((member) => member.getRole() === 'lead');
+                    return hasLead || 'Team must have a lead before setting budget';
+                }
+            }
+        });
+
+        expect(() => o.getOrg().getDivisionsAt(0).getTeamsAt(0).setBudget(600000)).not.toThrow();
+    });
+});

--- a/test/context-aware-construction.test.js
+++ b/test/context-aware-construction.test.js
@@ -1,0 +1,67 @@
+import { describe, expect, test } from '@jest/globals';
+import { transmute } from '../dist/index.js';
+
+describe('Context-aware construction and updates', () => {
+    test('does not invoke validators while constructing the object graph', () => {
+        let validationCalls = 0;
+
+        const user = transmute(
+            { profile: { age: 30 } },
+            {
+                validateInput: true,
+                rules: {
+                    'root.profile.age': () => {
+                        validationCalls += 1;
+                        return true;
+                    }
+                }
+            }
+        );
+
+        expect(validationCalls).toBe(0);
+
+        user.getProfile().setAge(31);
+
+        expect(validationCalls).toBe(1);
+    });
+
+    test('failed validation does not mutate the previous value', () => {
+        const user = transmute(
+            { age: 30 },
+            {
+                validateInput: true,
+                rules: {
+                    age: (value) => value >= 18 || 'Must be an adult'
+                }
+            }
+        );
+
+        expect(() => user.setAge(15)).toThrowError('Must be an adult');
+        expect(user.getAge()).toBe(30);
+    });
+
+    test('context references point to the current model and root model', () => {
+        let receivedContext;
+
+        const user = transmute(
+            { profile: { age: 30 } },
+            {
+                validateInput: true,
+                rules: {
+                    'root.profile.age': (value, context) => {
+                        receivedContext = context;
+                        return true;
+                    }
+                }
+            }
+        );
+
+        const profile = user.getProfile();
+        profile.setAge(31);
+
+        expect(receivedContext.parentObject).toBe(profile);
+        expect(receivedContext.rootObject).toBe(user);
+        expect(receivedContext.getParent()).toBe(profile);
+        expect(receivedContext.getRoot()).toBe(user);
+    });
+});

--- a/test/context-aware-integration.test.js
+++ b/test/context-aware-integration.test.js
@@ -1,0 +1,82 @@
+import { describe, expect, test } from '@jest/globals';
+import { transmute } from '../dist/index.js';
+
+describe('Context-aware integration and errors', () => {
+    test('includes path details in validation errors', () => {
+        const o = transmute(
+            { departments: [{ name: 'Eng', budget: 500000, limit: 1000000 }] },
+            {
+                validateInput: true,
+                rules: {
+                    'root.departments.budget': (value, context) => {
+                        const limit = context.parentObject.getLimit();
+                        return value <= limit || `Department budget ${value} exceeds limit ${limit} at path: ${context.path}`;
+                    }
+                }
+            }
+        );
+
+        expect(() => o.getDepartmentsAt(0).setBudget(1500000)).toThrowError(
+            /Department budget 1500000 exceeds limit 1000000 at path: root\.departments\.budget/
+        );
+    });
+
+    test('includes array indexes in validation errors', () => {
+        const o = transmute(
+            {
+                items: [
+                    { id: 'I-1', name: 'Item 1' },
+                    { id: 'I-2', name: 'Item 2' }
+                ]
+            },
+            {
+                validateInput: true,
+                rules: {
+                    'root.items.id': (value, context) =>
+                        value.startsWith('I-') || `Item at index ${context.index} has invalid ID: ${value}. Expected to start with 'I-'`
+                }
+            }
+        );
+
+        expect(() => o.getItemsAt(1).setId('INVALID')).toThrowError(/Item at index 1 has invalid ID: INVALID/);
+    });
+
+    test('validates a complete order across nested and array context', () => {
+        const data = {
+            orderId: 'ORD-001',
+            customer: { name: 'Alice', email: 'alice@example.com', country: 'US' },
+            items: [
+                { id: 'ITEM-1', quantity: 5, price: 100, maxQuantity: 10 },
+                { id: 'ITEM-2', quantity: 3, price: 200, maxQuantity: 5 }
+            ],
+            shipping: { method: 'standard', country: 'US', cost: 10 },
+            status: 'pending'
+        };
+
+        const o = transmute(data, {
+            validateInput: true,
+            rules: {
+                'root.customer.email': (value) =>
+                    /^[\w.-]+@[\w.-]+\.(com|org|net)$/.test(value) || 'US customers require .com/.org/.net email',
+                'root.items.quantity': (value, context) => {
+                    const maxQuantity = context.parentObject.getMaxQuantity();
+                    return value <= maxQuantity || `Quantity ${value} exceeds maximum ${maxQuantity}`;
+                },
+                'root.shipping.country': (value, context) => {
+                    const customerCountry = context.rootObject.getCustomer().getCountry();
+                    return value === customerCountry || `Shipping country must match customer country (${customerCountry})`;
+                },
+                'root.status': (value) =>
+                    ['pending', 'processing', 'shipped'].includes(value) || `Invalid status. Allowed: pending, processing, shipped`
+            }
+        });
+
+        expect(() => o.getCustomer().setEmail('alice@example.com')).not.toThrow();
+        expect(() => o.getItemsAt(0).setQuantity(8)).not.toThrow();
+        expect(() => o.getShipping().setCountry('US')).not.toThrow();
+        expect(() => o.setStatus('processing')).not.toThrow();
+        expect(() => o.getItemsAt(0).setQuantity(15)).toThrowError(/exceeds maximum/);
+        expect(() => o.getShipping().setCountry('CA')).toThrowError(/must match customer country/);
+        expect(() => o.setStatus('cancelled')).toThrowError(/Invalid status/);
+    });
+});

--- a/test/context-aware-navigation.test.js
+++ b/test/context-aware-navigation.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, test } from '@jest/globals';
+import { transmute } from '../dist/index.js';
+
+describe('Context-aware navigation', () => {
+    test('validates nested fields using the full path', () => {
+        const o = transmute(
+            {
+                company: 'TechCorp',
+                departments: [{ name: 'Engineering', manager: { contact: '+91-040-123-4567' } }]
+            },
+            {
+                validateInput: true,
+                rules: {
+                    contact: (value, context) => {
+                        if (context.path.includes('manager') && context.path.includes('departments')) {
+                            return /^\+91-\d{3}-\d{3}-\d{4}$/.test(value) || 'Invalid manager contact format';
+                        }
+                        return true;
+                    }
+                }
+            }
+        );
+
+        expect(() => o.getDepartmentsAt(0).getManager().setContact('+91-040-123-7890')).not.toThrow();
+        expect(() => o.getDepartmentsAt(0).getManager().setContact('invalid')).toThrowError('Invalid manager contact format');
+    });
+
+    test('selects validation by path location', () => {
+        const o = transmute(
+            { billing: { phone: '555-1234' }, shipping: { phone: '+1-555-1234' } },
+            {
+                validateInput: true,
+                rules: {
+                    phone: (value, context) => {
+                        if (context.path.includes('billing')) {
+                            return /^\d{3}-\d{4}$/.test(value) || 'Invalid billing phone format';
+                        }
+                        if (context.path.includes('shipping')) {
+                            return /^\+1-\d{3}-\d{4}$/.test(value) || 'Invalid shipping phone format';
+                        }
+                        return true;
+                    }
+                }
+            }
+        );
+
+        expect(() => o.getBilling().setPhone('555-1234')).not.toThrow();
+        expect(() => o.getShipping().setPhone('+1-555-1234')).not.toThrow();
+        expect(() => o.getBilling().setPhone('+1-555-1234')).toThrowError('Invalid billing phone format');
+        expect(() => o.getShipping().setPhone('555-1234')).toThrowError('Invalid shipping phone format');
+    });
+
+    test('supports parent and root helper methods', () => {
+        const o = transmute(
+            { version: '1.0', settings: { minAge: 18 } },
+            {
+                validateInput: true,
+                rules: {
+                    'root.settings.minAge': (value, context) => {
+                        const root = context.getRoot();
+                        const parent = context.getParent();
+                        expect(parent).toBe(root.getSettings());
+                        return root.getVersion() === '1.0' ? value >= 18 || 'Minimum age must be 18 or older' : true;
+                    }
+                }
+            }
+        );
+
+        expect(() => o.getSettings().setMinAge(21)).not.toThrow();
+        expect(() => o.getSettings().setMinAge(16)).toThrowError('Minimum age must be 18 or older');
+    });
+
+    test('supports deep parent navigation', () => {
+        const data = {
+            company: 'TechCorp',
+            departments: [{ name: 'Engineering', employees: [{ id: 'E-1001', projects: [{ budget: 100000 }] }] }]
+        };
+        const o = transmute(data, {
+            validateInput: true,
+            rules: {
+                'root.departments.employees.projects.budget': (value, context) => {
+                    expect(context.parentObject.getParent().getId()).toBe('E-1001');
+                    return value > 0 || 'Budget must be positive';
+                }
+            }
+        });
+
+        expect(() => o.getDepartmentsAt(0).getEmployeesAt(0).getProjectsAt(0).setBudget(200000)).not.toThrow();
+    });
+});

--- a/test/context-aware-rules.test.js
+++ b/test/context-aware-rules.test.js
@@ -1,0 +1,67 @@
+import { describe, expect, test } from '@jest/globals';
+import { transmute } from '../dist/index.js';
+
+describe('Context-aware validator contract', () => {
+    test('passes context to a validator', () => {
+        let receivedContext;
+
+        const user = transmute(
+            { email: 'test@example.com' },
+            {
+                validateInput: true,
+                rules: {
+                    email: (value, context) => {
+                        receivedContext = context;
+                        return /^\S+@\S+\.\S+$/.test(value) || 'Invalid email';
+                    }
+                }
+            }
+        );
+
+        user.setEmail('valid@test.com');
+
+        expect(receivedContext.key).toBe('email');
+        expect(receivedContext.path).toBe('email');
+        expect(receivedContext.value).toBe('valid@test.com');
+        expect(receivedContext.rootObject).toBe(user);
+        expect(receivedContext.parentObject).toBe(user);
+        expect(receivedContext.getRoot()).toBe(user);
+        expect(receivedContext.getParent()).toBe(user);
+    });
+
+    test('supports JavaScript validators that declare only the value parameter', () => {
+        const user = transmute(
+            { email: 'test@example.com' },
+            {
+                validateInput: true,
+                rules: {
+                    email: (value) => /^\S+@\S+\.\S+$/.test(value) || 'Invalid email'
+                }
+            }
+        );
+
+        expect(() => user.setEmail('invalid-email')).toThrowError('Invalid email');
+        expect(() => user.setEmail('valid@test.com')).not.toThrow();
+    });
+
+    test('supports mixed value-only and context-aware validators', () => {
+        const user = transmute(
+            { email: 'test@example.com', age: 25, confirmPassword: 'secret123', password: 'secret123' },
+            {
+                validateInput: true,
+                rules: {
+                    email: (value) => /^\S+@\S+\.\S+$/.test(value) || 'Invalid email',
+                    age: (value) => value >= 18 || 'Must be 18 or older',
+                    confirmPassword: (value, context) => context.parentObject.getPassword() === value || 'Passwords do not match'
+                }
+            }
+        );
+
+        expect(() => user.setEmail('new@test.com')).not.toThrow();
+        expect(() => user.setAge(21)).not.toThrow();
+        expect(() => user.setConfirmPassword('secret123')).not.toThrow();
+        expect(() => user.setEmail('invalid')).toThrowError('Invalid email');
+        expect(() => user.setAge(16)).toThrowError('Must be 18 or older');
+        expect(() => user.setConfirmPassword('wrong')).toThrowError('Passwords do not match');
+    });
+});

--- a/test/toJson.test.js
+++ b/test/toJson.test.js
@@ -36,7 +36,7 @@ describe('Converting transmuted object to JSON', () => {
         try {
             JSON.parse(transmutedUser);
         } catch (e) {
-            expect(e.toString()).toBe('SyntaxError: Unexpected token o in JSON at position 1');
+            expect(e.toString()).toBe('SyntaxError: "[object Object]" is not valid JSON');
         }
     });
 

--- a/test/validator-edge-cases.test.js
+++ b/test/validator-edge-cases.test.js
@@ -1,0 +1,84 @@
+import { describe, expect, test } from '@jest/globals';
+import { transmute } from '../dist/index.js';
+
+describe('Validator edge cases', () => {
+    test('passes context to validators with default parameters', () => {
+        let receivedContext;
+
+        const user = transmute(
+            { age: 30 },
+            {
+                validateInput: true,
+                rules: {
+                    age: (value, context = {}) => {
+                        receivedContext = context;
+                        return true;
+                    }
+                }
+            }
+        );
+
+        user.setAge(31);
+
+        expect(receivedContext.key).toBe('age');
+        expect(receivedContext.value).toBe(31);
+    });
+
+    test('passes the final array index to indexed validators', () => {
+        let receivedIndex;
+
+        const user = transmute(
+            { contacts: ['a', 'b', 'c'] },
+            {
+                validateInput: true,
+                rules: {
+                    contacts: (value, context) => {
+                        receivedIndex = context.index;
+                        return true;
+                    }
+                }
+            }
+        );
+
+        user.setContactsAt(2, 'updated');
+
+        expect(receivedIndex).toBe(2);
+    });
+
+    test('supports empty arrays without invoking a validator', () => {
+        let validationCalls = 0;
+
+        const user = transmute(
+            { contacts: [] },
+            {
+                validateInput: true,
+                rules: {
+                    contacts: () => {
+                        validationCalls += 1;
+                        return true;
+                    }
+                }
+            }
+        );
+
+        expect(user.getContacts()).toEqual([]);
+        expect(validationCalls).toBe(0);
+    });
+
+    test('propagates exceptions thrown by validators', () => {
+        const user = transmute(
+            { age: 30 },
+            {
+                validateInput: true,
+                rules: {
+                    age: () => {
+                        throw new Error('validator crashed');
+                    }
+                }
+            }
+        );
+
+        expect(() => user.setAge(31)).toThrowError('validator crashed');
+        expect(user.getAge()).toBe(30);
+    });
+});


### PR DESCRIPTION
### Description

Add object-graph context to validators so rules can validate values against sibling, parent, root, path, and array-index information.

Separate model construction from public setter validation by using internal initialization methods. This removes construction-time validation state while preserving fail-fast validation for updates.

Also split the context-aware tests into focused suites covering construction, navigation, arrays, business rules, edge cases, errors, and integration scenarios.

Note: configuration is still module-level and merged globally. Per-model configuration isolation remains a separate follow-up change.

- Add ValidatorContext with parent, root, path, and array index access
- Use one context-aware ValidatorFn signature
- Initialize generated models through internal methods without validation
- Remove construction-time validation state and preserve fail-fast setters
- Split context-aware tests into focused suites
- Add construction, edge-case, navigation, array, business, and integration coverage
- Fix example imports and formatting issues

Fixes: #20 