### PR TITLE
feat: add per-model rule updates

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,10 @@ export type Config = {
     rules?: Record<string, ValidatorFn>;
 };
 
+export type UpdateRulesOptions = {
+    mergeRules?: boolean;
+};
+
 type ModelConfig = Required<Config>;
 
 type ValidateRuleFn = (
@@ -65,6 +69,7 @@ type ValidateRuleFn = (
 
 type DynamicClassInstance = IStringIndex & {
     setInternalReferences: (root: unknown, parent: unknown, index?: number) => unknown;
+    updateRules: (rules: Record<string, ValidatorFn>, options?: UpdateRulesOptions) => DynamicClassInstance;
     toJson: () => IStringIndex;
     clone: () => IStringIndex;
     getMetaInfo: () => MetaInfo;
@@ -75,7 +80,7 @@ type DynamicClassInstance = IStringIndex & {
 };
 
 type DynamicClassConstructor = {
-    new (): DynamicClassInstance;
+    new (modelConfig: ModelConfig): DynamicClassInstance;
     prototype: IStringIndex;
 };
 
@@ -344,12 +349,15 @@ const generateDynamicClassInstance = function (
     const dynamicClassDefinition = `
         return class ${capitalize(normalize(className))} {
           ${privateProperties}
+          #modelConfig;
           #nameSpace = ${nameSpace.trim().length > 0 ? `'${nameSpace.trim()}'` : 'undefined'};
           #root = undefined;
           #parent = undefined;
           #index = undefined;
 
-          constructor() {}
+          constructor(modelConfig) {
+                this.#modelConfig = modelConfig;
+        }
 
           getNameSpace() {
             if (this.#nameSpace != null) {
@@ -376,6 +384,12 @@ const generateDynamicClassInstance = function (
           getIndex() {
             return this.#index;
           }
+
+          updateRules(rules, options = {}) {
+            const nextRules = options.mergeRules ? { ...this.#modelConfig.rules, ...rules } : { ...rules };
+            this.#modelConfig.rules = nextRules;
+            return this.getRoot();
+         }
 
           ${initializationMethods}
 
@@ -435,7 +449,7 @@ const generateDynamicClassInstance = function (
         };
     }
 
-    const instance = new dynamicClass();
+    const instance = new dynamicClass(configForModel);
 
     // Store navigation metadata on every generated instance. The root reference
     // enables access to the full object graph, the parent reference enables

--- a/test/update-model-rules.test.js
+++ b/test/update-model-rules.test.js
@@ -1,0 +1,98 @@
+import { describe, expect, test } from '@jest/globals';
+import { transmute } from '../dist/index.js';
+
+describe('Updating model validation rules', () => {
+    test('replaces existing rules by default', () => {
+        const user = transmute(
+            { age: 30, name: 'Jane' },
+            {
+                validateInput: true,
+                rules: {
+                    age: (value) => value >= 18 || 'Age rule',
+                    name: (value) => value.length > 0 || 'Name rule'
+                }
+            }
+        );
+
+        user.updateRules({ age: (value) => value >= 21 || 'Updated age rule' });
+
+        expect(() => user.setAge(20)).toThrowError('Updated age rule');
+        expect(() => user.setName('')).not.toThrow();
+    });
+
+    test('merges rules only when mergeRules is enabled', () => {
+        const user = transmute(
+            { age: 30, name: 'Jane' },
+            {
+                validateInput: true,
+                rules: {
+                    age: (value) => value >= 18 || 'Age rule'
+                }
+            }
+        );
+
+        user.updateRules({ name: (value) => value.length > 0 || 'Name rule' }, { mergeRules: true });
+
+        expect(() => user.setAge(17)).toThrowError('Age rule');
+        expect(() => user.setName('')).toThrowError('Name rule');
+    });
+
+    test('applies updated rules to nested properties and array elements', () => {
+        const user = transmute({ profile: { age: 30 }, contacts: ['primary', 'secondary'] }, { validateInput: true });
+
+        user.updateRules({
+            'root.profile.age': (value) => value >= 18 || 'Nested age rule',
+            contacts: (value, context) => context.index !== 0 || value === 'primary' || 'Primary contact rule'
+        });
+
+        expect(() => user.getProfile().setAge(17)).toThrowError('Nested age rule');
+        expect(() => user.setContactsAt(0, 'secondary')).toThrowError('Primary contact rule');
+    });
+
+    test('updates from nested models return the root model', () => {
+        const user = transmute({ profile: { age: 30 } }, { validateInput: true });
+        const returned = user.getProfile().updateRules({ 'root.profile.age': (value) => value >= 18 || 'Age rule' });
+
+        expect(returned).toBe(user);
+        expect(() => user.getProfile().setAge(17)).toThrowError('Age rule');
+    });
+
+    test('does not revalidate existing values during an update', () => {
+        const user = transmute({ age: 30 }, { validateInput: true });
+        user.updateRules({ age: (value) => value >= 18 || 'Age rule' });
+
+        expect(user.getAge()).toBe(30);
+        expect(() => user.setAge(17)).toThrowError('Age rule');
+    });
+
+    test('copies the caller rules map', () => {
+        const rules = { age: (value) => value >= 18 || 'Age rule' };
+        const user = transmute({ age: 30 }, { validateInput: true });
+
+        user.updateRules(rules);
+        rules.age = (value) => value >= 5 || 'Changed caller rule';
+
+        expect(() => user.setAge(10)).toThrowError('Age rule');
+    });
+
+    test('isolates updates between models', () => {
+        const first = transmute({ age: 30 }, { validateInput: true });
+        const second = transmute({ age: 30 }, { validateInput: true });
+
+        first.updateRules({ age: (value) => value >= 18 || 'First model rule' });
+
+        expect(() => first.setAge(10)).toThrowError('First model rule');
+        expect(() => second.setAge(10)).not.toThrow();
+    });
+
+    test('clones preserve rules at clone time', () => {
+        const user = transmute({ age: 30 }, { validateInput: true });
+        user.updateRules({ age: (value) => value >= 18 || 'Original rule' });
+
+        const clone = user.clone();
+        user.updateRules({ age: (value) => value >= 5 || 'Updated original rule' });
+
+        expect(() => user.setAge(4)).toThrowError('Updated original rule');
+        expect(() => clone.setAge(10)).toThrowError('Original rule');
+    });
+});


### PR DESCRIPTION
### Description

Add `updateRules()` to transmuted models with replacement by default and explicit `mergeRules` support. Keep rule updates isolated per model, apply them to nested and array models, preserve rules when cloning, and avoid revalidating existing values.

Add focused tests covering replacement, merging, model isolation, nested updates, caller-map copying, chaining, and clone behavior.

Fixes: #24