### PR TITLE
feat(#26): Validation hardening roadmap

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -208,6 +208,7 @@ const validateObjectGraph = function (instance: DynamicClassInstance): DynamicCl
             getRoot: () => unknown;
             utility: {
                 typeMap?: Record<string, string>;
+                elementTypeMap?: Record<string, string[]>;
                 getTypeOfObject: typeof getTypeOfObject;
                 validateRule: ValidateRuleFn;
             };
@@ -224,7 +225,15 @@ const validateObjectGraph = function (instance: DynamicClassInstance): DynamicCl
         typedInstance.utility.validateRule(typedInstance.getNameSpace(), key, value, undefined, typedInstance, typedInstance.getRoot());
 
         if (Array.isArray(value)) {
-            value.forEach((item) => {
+            const elementTypes = typedInstance.utility.elementTypeMap?.[key];
+            value.forEach((item, itemIndex) => {
+                const expectedElementType = elementTypes?.[itemIndex];
+                const actualElementType = typedInstance.utility.getTypeOfObject(item);
+                if (expectedElementType != null && actualElementType !== expectedElementType) {
+                    throw new Error(
+                        `Type mismatch at index ${itemIndex} [${key}]: argument of type ${expectedElementType} expected but got ${actualElementType} instead`
+                    );
+                }
                 if (item != null && typeof item === 'object' && hasObjectMetaInfo(item)) {
                     (item as DynamicClassInstance).validate();
                 }
@@ -268,6 +277,11 @@ const generateDynamicClassInstance = function (
     const primitiveKeys = keys.filter((key) => getTypeOfObject(o[key]) !== 'object' && getTypeOfObject(o[key]) !== 'array');
     const objectKeys = keys.filter((key) => getTypeOfObject(o[key]) === 'object');
     const arrayKeys = keys.filter((key) => getTypeOfObject(o[key]) === 'array');
+    // Capture each array's original per-index types so validate() can enforce the same contract as indexed setters, even for heterogeneous arrays.
+    const arrayElementTypes = arrayKeys.reduce(
+        (acc, key) => ({ ...acc, [key]: (o[key] as unknown[]).map((v) => getTypeOfObject(v)) }),
+        {} as Record<string, string[]>
+    );
     const privateProperties = generateStringFromArray(keys.map((key) => `${HASH}${normalize(key)};`));
     const initializationMethods = generateStringFromArray(
         keys.map((key) => {
@@ -381,6 +395,12 @@ const generateDynamicClassInstance = function (
                 const value = this.${HASH}${normalize(key)};
                 if (this.utility.getTypeOfObject(i) === 'number') {
                     if (i >= 0 && i < value.length) {
+                        // Compare against the type currently held at this index so heterogeneous arrays keep each slot's own contract.
+                        const expectedType = this.utility.getTypeOfObject(value[i]);
+                        const typeOfValue = this.utility.getTypeOfObject(v);
+                        if (typeOfValue !== expectedType) {
+                            throw 'Type mismatch: argument of type ' + expectedType + ' expected but got ' + typeOfValue + ' instead';
+                        }
                         this.utility.validateRule(
                           this.getNameSpace() COMMA_PLACEHOLDER 
                           '${key}' COMMA_PLACEHOLDER 
@@ -496,6 +516,7 @@ const generateDynamicClassInstance = function (
         // Utility to check the type
         dynamicClass.prototype.utility = {
             typeMap: propertyTypes,
+            elementTypeMap: arrayElementTypes,
             getTypeOfObject,
             validateRule: (
                 nameSpace: string | undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,11 +45,14 @@ export type ValidatorContext = {
 
 export type ValidatorFn = (value: unknown, context: ValidatorContext) => boolean | string;
 
+export type AsyncValidatorFn = (value: unknown, context: ValidatorContext) => boolean | string | Promise<boolean | string>;
+
 export type Config = {
     validateInput?: boolean;
     validateOnCreate?: boolean;
     cloneable?: boolean;
     rules?: Record<string, ValidatorFn>;
+    asyncRules?: Record<string, AsyncValidatorFn>;
 };
 
 export type UpdateRulesOptions = {
@@ -69,17 +72,30 @@ type ValidateRuleFn = (
     index?: number
 ) => void;
 
+type ValidateAsyncRuleFn = (
+    nameSpace: string | undefined,
+    key: string,
+    value: unknown,
+    parentObject?: unknown,
+    rootObject?: unknown,
+    index?: number
+) => Promise<void>;
+
 type DynamicClassInstance = IStringIndex & {
     setInternalReferences: (root: unknown, parent: unknown, index?: number) => unknown;
     updateRules: (rules: Record<string, ValidatorFn>, options?: UpdateRulesOptions) => DynamicClassInstance;
     removeRules: (...keys: string[]) => DynamicClassInstance;
+    updateAsyncRules: (rules: Record<string, AsyncValidatorFn>, options?: UpdateRulesOptions) => DynamicClassInstance;
+    removeAsyncRules: (...keys: string[]) => DynamicClassInstance;
     validate: () => DynamicClassInstance;
+    validateAsync: () => Promise<DynamicClassInstance>;
     toJson: () => IStringIndex;
     clone: () => IStringIndex;
     getMetaInfo: () => MetaInfo;
     utility: {
         getTypeOfObject: typeof getTypeOfObject;
         validateRule: ValidateRuleFn;
+        validateAsyncRule: ValidateAsyncRuleFn;
     };
 };
 
@@ -114,7 +130,7 @@ const matchesWildcardPath = function (pattern: string, path: string): boolean {
 };
 
 /* Find the first configured rule key whose wildcard pattern matches the given namespaced path */
-const findWildcardRuleKey = function (rules: Record<string, ValidatorFn>, nsKey: string): string | undefined {
+const findWildcardRuleKey = function <T>(rules: Record<string, T>, nsKey: string): string | undefined {
     return Object.keys(rules).find((ruleKey) => ruleKey.includes('*') && matchesWildcardPath(ruleKey, nsKey));
 };
 
@@ -186,6 +202,75 @@ const validateRule = function (
     }
 };
 
+/* Async counterpart to validateRule, used only by validateAsync() so synchronous setters stay untouched */
+const validateAsyncRule = async function (
+    modelConfig: ModelConfig,
+    nameSpace: string | undefined,
+    key: string,
+    value: unknown,
+    parentObject?: unknown,
+    rootObject?: unknown,
+    index?: number
+): Promise<void> {
+    if (modelConfig.asyncRules == null) {
+        return;
+    }
+
+    const nsKey = nameSpace != null && nameSpace.trim().length > 0 ? `${nameSpace}.${key}` : undefined;
+
+    let usedKey = key;
+    let validator: AsyncValidatorFn | undefined;
+    const contextPath = nameSpace === 'root' ? key : (nsKey ?? key);
+    const wildcardKey = nsKey != null ? findWildcardRuleKey(modelConfig.asyncRules, nsKey) : undefined;
+    if (nsKey != null && modelConfig.asyncRules[nsKey] != null) {
+        validator = modelConfig.asyncRules[nsKey];
+        usedKey = nsKey;
+    } else if (nsKey != null && wildcardKey != null) {
+        validator = modelConfig.asyncRules[wildcardKey];
+        usedKey = nsKey;
+    } else if (modelConfig.asyncRules[key] != null) {
+        validator = modelConfig.asyncRules[key];
+        usedKey = key;
+    }
+
+    if (validator == null) {
+        return;
+    }
+
+    const validate = async (v: unknown, i?: number) => {
+        const finalIndex = i ?? index ?? (parentObject as { getIndex?: () => number })?.getIndex?.();
+        const context: ValidatorContext = {
+            key,
+            path: contextPath,
+            value: v,
+            parentObject,
+            rootObject,
+            index: finalIndex,
+            getParent: () => parentObject,
+            getRoot: () => rootObject
+        };
+        const validationResponse = await (validator as AsyncValidatorFn)(v, context);
+
+        if (validationResponse !== true) {
+            if (typeof validationResponse === 'string') {
+                if (finalIndex != null) {
+                    throw new Error(`Validation error at index ${finalIndex} [${usedKey}]: ${validationResponse}`);
+                }
+                throw new Error(`Validation error [${usedKey}]: ${validationResponse}`);
+            }
+            throw new Error(`Validation failed for property ${usedKey} with value ${v}`);
+        }
+    };
+
+    if (Array.isArray(value)) {
+        for (const [idx, v] of value.entries()) {
+            await validate(v, idx);
+        }
+        return;
+    }
+    await validate(value);
+};
+
 const normalize = function (s: string) {
     if (!isNaN(Number(s[0]))) {
         s = '_' + s;
@@ -206,7 +291,8 @@ const normalizeConfig = function (cfg?: Config): ModelConfig {
         validateInput: cfg?.validateInput ?? false,
         validateOnCreate: cfg?.validateOnCreate ?? false,
         cloneable: cfg?.cloneable ?? true,
-        rules: { ...(cfg?.rules ?? {}) }
+        rules: { ...(cfg?.rules ?? {}) },
+        asyncRules: { ...(cfg?.asyncRules ?? {}) }
     };
 };
 
@@ -266,6 +352,61 @@ const validateObjectGraph = function (instance: DynamicClassInstance): DynamicCl
             (value as DynamicClassInstance).validate();
         }
     });
+
+    return instance;
+};
+
+/* Async counterpart to validateObjectGraph: runs the same sync checks first, then awaits any configured async rules */
+const validateObjectGraphAsync = async function (instance: DynamicClassInstance): Promise<DynamicClassInstance> {
+    validateObjectGraph(instance);
+
+    const metaInfo = instance.getMetaInfo();
+    const keys = [
+        ...(metaInfo.primitiveKeys != null && metaInfo.primitiveKeys.length > 0 ? metaInfo.primitiveKeys.split(',') : []),
+        ...(metaInfo.objectKeys != null && metaInfo.objectKeys.length > 0 ? metaInfo.objectKeys.split(',') : []),
+        ...(metaInfo.arrayKeys != null && metaInfo.arrayKeys.length > 0 ? metaInfo.arrayKeys.split(',') : [])
+    ].filter(Boolean);
+
+    for (const key of keys) {
+        const getter = `get${capitalize(normalize(key))}`;
+        if (typeof instance[getter] !== 'function') {
+            continue;
+        }
+
+        const typedInstance = instance as DynamicClassInstance & {
+            getNameSpace: () => string;
+            getRoot: () => unknown;
+            utility: {
+                validateAsyncRule: ValidateAsyncRuleFn;
+            };
+        };
+
+        const value = (instance[getter] as GetterFn)();
+        await typedInstance.utility.validateAsyncRule(typedInstance.getNameSpace(), key, value, typedInstance, typedInstance.getRoot());
+
+        if (Array.isArray(value)) {
+            for (const item of value) {
+                if (
+                    item != null &&
+                    typeof item === 'object' &&
+                    hasObjectMetaInfo(item) &&
+                    typeof (item as DynamicClassInstance).validateAsync === 'function'
+                ) {
+                    await (item as DynamicClassInstance).validateAsync();
+                }
+            }
+            continue;
+        }
+
+        if (
+            value != null &&
+            typeof value === 'object' &&
+            hasObjectMetaInfo(value) &&
+            typeof (value as DynamicClassInstance).validateAsync === 'function'
+        ) {
+            await (value as DynamicClassInstance).validateAsync();
+        }
+    }
 
     return instance;
 };
@@ -497,6 +638,22 @@ const generateDynamicClassInstance = function (
             return this.getRoot();
           }
 
+          updateAsyncRules(rules, options = {}) {
+            const nextRules = options.mergeRules ? { ...this.#modelConfig.asyncRules, ...rules } : { ...rules };
+            if (Array.isArray(options.remove)) {
+                options.remove.forEach((key) => delete nextRules[key]);
+            }
+            this.#modelConfig.asyncRules = nextRules;
+            return this.getRoot();
+          }
+
+          removeAsyncRules(...keys) {
+            const nextRules = { ...this.#modelConfig.asyncRules };
+            keys.forEach((key) => delete nextRules[key]);
+            this.#modelConfig.asyncRules = nextRules;
+            return this.getRoot();
+          }
+
           ${initializationMethods}
 
           ${configForModel.validateInput ? accessorMethodsWithValidation : accessorMethods}
@@ -530,6 +687,10 @@ const generateDynamicClassInstance = function (
             return validateObjectGraph(this);
         };
 
+        dynamicClass.prototype.validateAsync = function (this: DynamicClassInstance) {
+            return validateObjectGraphAsync(this);
+        };
+
         // Construct a meta-info of the instance
         dynamicClass.prototype.getMetaInfo = function () {
             let o = {};
@@ -557,7 +718,15 @@ const generateDynamicClassInstance = function (
                 parentObject?: unknown,
                 rootObject?: unknown,
                 index?: number
-            ) => validateRule(configForModel, nameSpace, key, value, validator, parentObject, rootObject, index)
+            ) => validateRule(configForModel, nameSpace, key, value, validator, parentObject, rootObject, index),
+            validateAsyncRule: (
+                nameSpace: string | undefined,
+                key: string,
+                value: unknown,
+                parentObject?: unknown,
+                rootObject?: unknown,
+                index?: number
+            ) => validateAsyncRule(configForModel, nameSpace, key, value, parentObject, rootObject, index)
         };
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ export type ValidatorFn = (value: unknown, context: ValidatorContext) => boolean
 
 export type Config = {
     validateInput?: boolean;
+    validateOnCreate?: boolean;
     cloneable?: boolean;
     rules?: Record<string, ValidatorFn>;
 };
@@ -70,6 +71,7 @@ type ValidateRuleFn = (
 type DynamicClassInstance = IStringIndex & {
     setInternalReferences: (root: unknown, parent: unknown, index?: number) => unknown;
     updateRules: (rules: Record<string, ValidatorFn>, options?: UpdateRulesOptions) => DynamicClassInstance;
+    validate: () => DynamicClassInstance;
     toJson: () => IStringIndex;
     clone: () => IStringIndex;
     getMetaInfo: () => MetaInfo;
@@ -181,9 +183,61 @@ const generateStringFromArray = function (s: string[], joiner = ',', separator =
 const normalizeConfig = function (cfg?: Config): ModelConfig {
     return {
         validateInput: cfg?.validateInput ?? false,
+        validateOnCreate: cfg?.validateOnCreate ?? false,
         cloneable: cfg?.cloneable ?? true,
         rules: { ...(cfg?.rules ?? {}) }
     };
+};
+
+const validateObjectGraph = function (instance: DynamicClassInstance): DynamicClassInstance {
+    const metaInfo = instance.getMetaInfo();
+    const keys = [
+        ...(metaInfo.primitiveKeys != null && metaInfo.primitiveKeys.length > 0 ? metaInfo.primitiveKeys.split(',') : []),
+        ...(metaInfo.objectKeys != null && metaInfo.objectKeys.length > 0 ? metaInfo.objectKeys.split(',') : []),
+        ...(metaInfo.arrayKeys != null && metaInfo.arrayKeys.length > 0 ? metaInfo.arrayKeys.split(',') : [])
+    ].filter(Boolean);
+
+    keys.forEach((key) => {
+        const getter = `get${capitalize(normalize(key))}`;
+        if (typeof instance[getter] !== 'function') {
+            return;
+        }
+
+        const typedInstance = instance as DynamicClassInstance & {
+            getNameSpace: () => string;
+            getRoot: () => unknown;
+            utility: {
+                typeMap?: Record<string, string>;
+                getTypeOfObject: typeof getTypeOfObject;
+                validateRule: ValidateRuleFn;
+            };
+        };
+
+        const value = (instance[getter] as GetterFn)();
+        const expectedType = typedInstance.utility.typeMap?.[key] ?? null;
+        const actualType = typedInstance.utility.getTypeOfObject(value);
+
+        if (expectedType != null && actualType !== expectedType) {
+            throw new Error(`Type mismatch: argument of type ${expectedType} expected but got ${actualType} instead`);
+        }
+
+        typedInstance.utility.validateRule(typedInstance.getNameSpace(), key, value, undefined, typedInstance, typedInstance.getRoot());
+
+        if (Array.isArray(value)) {
+            value.forEach((item) => {
+                if (item != null && typeof item === 'object' && hasObjectMetaInfo(item)) {
+                    (item as DynamicClassInstance).validate();
+                }
+            });
+            return;
+        }
+
+        if (value != null && typeof value === 'object' && hasObjectMetaInfo(value)) {
+            (value as DynamicClassInstance).validate();
+        }
+    });
+
+    return instance;
 };
 
 export const memorySizeOf = function (obj: IStringIndex) {
@@ -210,6 +264,7 @@ const generateDynamicClassInstance = function (
 ) {
     const configForModel = modelConfig ?? normalizeConfig();
     const keys = Object.keys(o);
+    const propertyTypes = keys.reduce((acc, key) => ({ ...acc, [key]: getTypeOfObject(o[key]) }), {} as Record<string, string>);
     const primitiveKeys = keys.filter((key) => getTypeOfObject(o[key]) !== 'object' && getTypeOfObject(o[key]) !== 'array');
     const objectKeys = keys.filter((key) => getTypeOfObject(o[key]) === 'object');
     const arrayKeys = keys.filter((key) => getTypeOfObject(o[key]) === 'array');
@@ -420,6 +475,10 @@ const generateDynamicClassInstance = function (
             };
         }
 
+        dynamicClass.prototype.validate = function (this: DynamicClassInstance) {
+            return validateObjectGraph(this);
+        };
+
         // Construct a meta-info of the instance
         dynamicClass.prototype.getMetaInfo = function () {
             let o = {};
@@ -436,6 +495,7 @@ const generateDynamicClassInstance = function (
         };
         // Utility to check the type
         dynamicClass.prototype.utility = {
+            typeMap: propertyTypes,
             getTypeOfObject,
             validateRule: (
                 nameSpace: string | undefined,
@@ -540,6 +600,9 @@ export function transmute(o: IStringIndex, config?: Config, className?: string):
     // Keep the root instance as its own root reference so every nested model can
     // access the complete transmuted object graph through ValidatorContext.getRoot().
     instance.setInternalReferences(instance, instance, undefined);
+    if (modelConfig.validateOnCreate) {
+        instance.validate();
+    }
     return instance;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ export type Config = {
 
 export type UpdateRulesOptions = {
     mergeRules?: boolean;
+    remove?: string[];
 };
 
 type ModelConfig = Required<Config>;
@@ -71,6 +72,7 @@ type ValidateRuleFn = (
 type DynamicClassInstance = IStringIndex & {
     setInternalReferences: (root: unknown, parent: unknown, index?: number) => unknown;
     updateRules: (rules: Record<string, ValidatorFn>, options?: UpdateRulesOptions) => DynamicClassInstance;
+    removeRules: (...keys: string[]) => DynamicClassInstance;
     validate: () => DynamicClassInstance;
     toJson: () => IStringIndex;
     clone: () => IStringIndex;
@@ -462,9 +464,19 @@ const generateDynamicClassInstance = function (
 
           updateRules(rules, options = {}) {
             const nextRules = options.mergeRules ? { ...this.#modelConfig.rules, ...rules } : { ...rules };
+            if (Array.isArray(options.remove)) {
+                options.remove.forEach((key) => delete nextRules[key]);
+            }
             this.#modelConfig.rules = nextRules;
             return this.getRoot();
          }
+
+          removeRules(...keys) {
+            const nextRules = { ...this.#modelConfig.rules };
+            keys.forEach((key) => delete nextRules[key]);
+            this.#modelConfig.rules = nextRules;
+            return this.getRoot();
+          }
 
           ${initializationMethods}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,21 @@ const getTypeOfObject = function (o: unknown) {
         .toLowerCase();
 };
 
+/* Match a dot-separated rule path against a pattern where '*' stands in for exactly one segment */
+const matchesWildcardPath = function (pattern: string, path: string): boolean {
+    const patternSegments = pattern.split('.');
+    const pathSegments = path.split('.');
+    if (patternSegments.length !== pathSegments.length) {
+        return false;
+    }
+    return patternSegments.every((segment, i) => segment === '*' || segment === pathSegments[i]);
+};
+
+/* Find the first configured rule key whose wildcard pattern matches the given namespaced path */
+const findWildcardRuleKey = function (rules: Record<string, ValidatorFn>, nsKey: string): string | undefined {
+    return Object.keys(rules).find((ruleKey) => ruleKey.includes('*') && matchesWildcardPath(ruleKey, nsKey));
+};
+
 /* Validate rule for a property */
 const validateRule = function (
     modelConfig: ModelConfig,
@@ -119,8 +134,12 @@ const validateRule = function (
 
         let usedKey = key;
         const contextPath = nameSpace === 'root' ? key : (nsKey ?? key);
+        const wildcardKey = nsKey != null ? findWildcardRuleKey(modelConfig.rules, nsKey) : undefined;
         if (nsKey != null && modelConfig.rules[nsKey] != null) {
             validator = validator ?? modelConfig.rules[nsKey];
+            usedKey = nsKey;
+        } else if (nsKey != null && wildcardKey != null) {
+            validator = validator ?? modelConfig.rules[wildcardKey];
             usedKey = nsKey;
         } else if (modelConfig.rules[key] != null) {
             validator = validator ?? modelConfig.rules[key];

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,22 @@ export type UpdateRulesOptions = {
     remove?: string[];
 };
 
+export type ValidationIssue = {
+    path: string; // Namespaced path of the offending property (e.g. "root.account.password")
+    key: string; // Property name
+    message: string; // Human-readable failure reason
+    index?: number; // Array index, when the failure is on a specific array element
+};
+
+export type ValidationResult = {
+    valid: boolean;
+    errors: ValidationIssue[];
+};
+
+export type ValidateOptions = {
+    collectErrors?: boolean;
+};
+
 type ModelConfig = Required<Config>;
 
 type ValidateRuleFn = (
@@ -87,8 +103,14 @@ type DynamicClassInstance = IStringIndex & {
     removeRules: (...keys: string[]) => DynamicClassInstance;
     updateAsyncRules: (rules: Record<string, AsyncValidatorFn>, options?: UpdateRulesOptions) => DynamicClassInstance;
     removeAsyncRules: (...keys: string[]) => DynamicClassInstance;
-    validate: () => DynamicClassInstance;
-    validateAsync: () => Promise<DynamicClassInstance>;
+    validate: {
+        (options?: { collectErrors?: false }): DynamicClassInstance;
+        (options: { collectErrors: true }): ValidationResult;
+    };
+    validateAsync: {
+        (options?: { collectErrors?: false }): Promise<DynamicClassInstance>;
+        (options: { collectErrors: true }): Promise<ValidationResult>;
+    };
     toJson: () => IStringIndex;
     clone: () => IStringIndex;
     getMetaInfo: () => MetaInfo;
@@ -411,6 +433,177 @@ const validateObjectGraphAsync = async function (instance: DynamicClassInstance)
     return instance;
 };
 
+/* Non-throwing counterpart to validateObjectGraph: collects every failure instead of stopping at the first one */
+const collectObjectGraphErrors = function (instance: DynamicClassInstance): ValidationIssue[] {
+    const errors: ValidationIssue[] = [];
+    const metaInfo = instance.getMetaInfo();
+    const keys = [
+        ...(metaInfo.primitiveKeys != null && metaInfo.primitiveKeys.length > 0 ? metaInfo.primitiveKeys.split(',') : []),
+        ...(metaInfo.objectKeys != null && metaInfo.objectKeys.length > 0 ? metaInfo.objectKeys.split(',') : []),
+        ...(metaInfo.arrayKeys != null && metaInfo.arrayKeys.length > 0 ? metaInfo.arrayKeys.split(',') : [])
+    ].filter(Boolean);
+
+    keys.forEach((key) => {
+        const getter = `get${capitalize(normalize(key))}`;
+        if (typeof instance[getter] !== 'function') {
+            return;
+        }
+
+        const typedInstance = instance as DynamicClassInstance & {
+            getNameSpace: () => string;
+            getRoot: () => unknown;
+            utility: {
+                typeMap?: Record<string, string>;
+                elementTypeMap?: Record<string, string[]>;
+                getTypeOfObject: typeof getTypeOfObject;
+                validateRule: ValidateRuleFn;
+            };
+        };
+
+        const nameSpace = typedInstance.getNameSpace();
+        const path = nameSpace === 'root' || nameSpace == null ? key : `${nameSpace}.${key}`;
+        const value = (instance[getter] as GetterFn)();
+        const expectedType = typedInstance.utility.typeMap?.[key] ?? null;
+        const actualType = typedInstance.utility.getTypeOfObject(value);
+
+        if (expectedType != null && actualType !== expectedType) {
+            errors.push({ path, key, message: `Type mismatch: argument of type ${expectedType} expected but got ${actualType} instead` });
+        }
+
+        try {
+            typedInstance.utility.validateRule(nameSpace, key, value, undefined, typedInstance, typedInstance.getRoot());
+        } catch (error) {
+            errors.push({ path, key, message: error instanceof Error ? error.message : String(error) });
+        }
+
+        if (Array.isArray(value)) {
+            const elementTypes = typedInstance.utility.elementTypeMap?.[key];
+            value.forEach((item, itemIndex) => {
+                const expectedElementType = elementTypes?.[itemIndex];
+                const actualElementType = typedInstance.utility.getTypeOfObject(item);
+                if (expectedElementType != null && actualElementType !== expectedElementType) {
+                    errors.push({
+                        path,
+                        key,
+                        index: itemIndex,
+                        message: `Type mismatch at index ${itemIndex} [${key}]: argument of type ${expectedElementType} expected but got ${actualElementType} instead`
+                    });
+                }
+                if (
+                    item != null &&
+                    typeof item === 'object' &&
+                    hasObjectMetaInfo(item) &&
+                    typeof (item as DynamicClassInstance).validate === 'function'
+                ) {
+                    errors.push(...((item as DynamicClassInstance).validate({ collectErrors: true }) as ValidationResult).errors);
+                }
+            });
+            return;
+        }
+
+        if (
+            value != null &&
+            typeof value === 'object' &&
+            hasObjectMetaInfo(value) &&
+            typeof (value as DynamicClassInstance).validate === 'function'
+        ) {
+            errors.push(...((value as DynamicClassInstance).validate({ collectErrors: true }) as ValidationResult).errors);
+        }
+    });
+
+    return errors;
+};
+
+/* Non-throwing counterpart to validateObjectGraphAsync: collects sync and async rule failures in a single recursive pass */
+const collectObjectGraphErrorsAsync = async function (instance: DynamicClassInstance): Promise<ValidationIssue[]> {
+    const errors: ValidationIssue[] = [];
+    const metaInfo = instance.getMetaInfo();
+    const keys = [
+        ...(metaInfo.primitiveKeys != null && metaInfo.primitiveKeys.length > 0 ? metaInfo.primitiveKeys.split(',') : []),
+        ...(metaInfo.objectKeys != null && metaInfo.objectKeys.length > 0 ? metaInfo.objectKeys.split(',') : []),
+        ...(metaInfo.arrayKeys != null && metaInfo.arrayKeys.length > 0 ? metaInfo.arrayKeys.split(',') : [])
+    ].filter(Boolean);
+
+    for (const key of keys) {
+        const getter = `get${capitalize(normalize(key))}`;
+        if (typeof instance[getter] !== 'function') {
+            continue;
+        }
+
+        const typedInstance = instance as DynamicClassInstance & {
+            getNameSpace: () => string;
+            getRoot: () => unknown;
+            utility: {
+                typeMap?: Record<string, string>;
+                elementTypeMap?: Record<string, string[]>;
+                getTypeOfObject: typeof getTypeOfObject;
+                validateRule: ValidateRuleFn;
+                validateAsyncRule: ValidateAsyncRuleFn;
+            };
+        };
+
+        const nameSpace = typedInstance.getNameSpace();
+        const path = nameSpace === 'root' || nameSpace == null ? key : `${nameSpace}.${key}`;
+        const value = (instance[getter] as GetterFn)();
+        const expectedType = typedInstance.utility.typeMap?.[key] ?? null;
+        const actualType = typedInstance.utility.getTypeOfObject(value);
+
+        if (expectedType != null && actualType !== expectedType) {
+            errors.push({ path, key, message: `Type mismatch: argument of type ${expectedType} expected but got ${actualType} instead` });
+        }
+
+        try {
+            typedInstance.utility.validateRule(nameSpace, key, value, undefined, typedInstance, typedInstance.getRoot());
+        } catch (error) {
+            errors.push({ path, key, message: error instanceof Error ? error.message : String(error) });
+        }
+
+        try {
+            await typedInstance.utility.validateAsyncRule(nameSpace, key, value, typedInstance, typedInstance.getRoot());
+        } catch (error) {
+            errors.push({ path, key, message: error instanceof Error ? error.message : String(error) });
+        }
+
+        if (Array.isArray(value)) {
+            const elementTypes = typedInstance.utility.elementTypeMap?.[key];
+            for (const [itemIndex, item] of value.entries()) {
+                const expectedElementType = elementTypes?.[itemIndex];
+                const actualElementType = typedInstance.utility.getTypeOfObject(item);
+                if (expectedElementType != null && actualElementType !== expectedElementType) {
+                    errors.push({
+                        path,
+                        key,
+                        index: itemIndex,
+                        message: `Type mismatch at index ${itemIndex} [${key}]: argument of type ${expectedElementType} expected but got ${actualElementType} instead`
+                    });
+                }
+                if (
+                    item != null &&
+                    typeof item === 'object' &&
+                    hasObjectMetaInfo(item) &&
+                    typeof (item as DynamicClassInstance).validateAsync === 'function'
+                ) {
+                    const nestedResult = (await (item as DynamicClassInstance).validateAsync({ collectErrors: true })) as ValidationResult;
+                    errors.push(...nestedResult.errors);
+                }
+            }
+            continue;
+        }
+
+        if (
+            value != null &&
+            typeof value === 'object' &&
+            hasObjectMetaInfo(value) &&
+            typeof (value as DynamicClassInstance).validateAsync === 'function'
+        ) {
+            const nestedResult = (await (value as DynamicClassInstance).validateAsync({ collectErrors: true })) as ValidationResult;
+            errors.push(...nestedResult.errors);
+        }
+    }
+
+    return errors;
+};
+
 export const memorySizeOf = function (obj: IStringIndex) {
     const formatByteSize = function (bytes: number) {
         const kiloByte = 1024;
@@ -683,11 +876,19 @@ const generateDynamicClassInstance = function (
             };
         }
 
-        dynamicClass.prototype.validate = function (this: DynamicClassInstance) {
+        dynamicClass.prototype.validate = function (this: DynamicClassInstance, options?: ValidateOptions) {
+            if (options?.collectErrors) {
+                const errors = collectObjectGraphErrors(this);
+                return { valid: errors.length === 0, errors };
+            }
             return validateObjectGraph(this);
         };
 
-        dynamicClass.prototype.validateAsync = function (this: DynamicClassInstance) {
+        dynamicClass.prototype.validateAsync = async function (this: DynamicClassInstance, options?: ValidateOptions) {
+            if (options?.collectErrors) {
+                const errors = await collectObjectGraphErrorsAsync(this);
+                return { valid: errors.length === 0, errors };
+            }
             return validateObjectGraphAsync(this);
         };
 

--- a/test/async-validation.test.js
+++ b/test/async-validation.test.js
@@ -1,0 +1,99 @@
+import { describe, expect, test } from '@jest/globals';
+import { transmute } from '../dist/index.js';
+
+describe('Asynchronous validation via validateAsync()', () => {
+    test('resolves when all async rules pass', async () => {
+        const user = transmute(
+            { email: 'alpha@techcorp.com' },
+            {
+                asyncRules: {
+                    email: async (value) => /@/.test(value) || 'Email must contain @'
+                }
+            }
+        );
+
+        await expect(user.validateAsync()).resolves.toBe(user);
+    });
+
+    test('rejects with the async rule message when it fails', async () => {
+        const user = transmute(
+            { email: 'not-an-email' },
+            {
+                asyncRules: {
+                    email: async (value) => /@/.test(value) || 'Email must contain @'
+                }
+            }
+        );
+
+        await expect(user.validateAsync()).rejects.toThrowError('Email must contain @');
+    });
+
+    test('still runs synchronous type and rule checks before awaiting async rules', async () => {
+        const user = transmute(
+            { age: 15 },
+            {
+                rules: {
+                    age: (value) => value >= 18 || 'Must be an adult'
+                },
+                asyncRules: {
+                    age: async () => true
+                }
+            }
+        );
+
+        await expect(user.validateAsync()).rejects.toThrowError('Must be an adult');
+    });
+
+    test('does not affect synchronous setters or validate()', () => {
+        const user = transmute(
+            { email: 'not-an-email' },
+            {
+                validateInput: true,
+                asyncRules: {
+                    email: async (value) => /@/.test(value) || 'Email must contain @'
+                }
+            }
+        );
+
+        expect(() => user.setEmail('still-not-an-email')).not.toThrow();
+        expect(() => user.validate()).not.toThrow();
+    });
+
+    test('recurses into nested objects and array elements', async () => {
+        const user = transmute({
+            profile: { email: 'bad' },
+            contacts: [{ email: 'bad' }]
+        });
+
+        user.getProfile().updateAsyncRules({ email: async (value) => /@/.test(value) || 'Nested email rule' });
+        await expect(user.validateAsync()).rejects.toThrowError('Nested email rule');
+
+        const user2 = transmute({
+            profile: { email: 'ok@techcorp.com' },
+            contacts: [{ email: 'bad' }]
+        });
+        user2.getContactsAt(0).updateAsyncRules({ email: async (value) => /@/.test(value) || 'Array element email rule' });
+        await expect(user2.validateAsync()).rejects.toThrowError('Array element email rule');
+    });
+
+    test('updateAsyncRules and removeAsyncRules manage async rules independently of sync rules', async () => {
+        const user = transmute({ email: 'not-an-email' });
+
+        user.updateAsyncRules({ email: async (value) => /@/.test(value) || 'Email must contain @' });
+        await expect(user.validateAsync()).rejects.toThrowError('Email must contain @');
+
+        user.removeAsyncRules('email');
+        await expect(user.validateAsync()).resolves.toBe(user);
+    });
+
+    test('supports wildcard async rule paths', async () => {
+        const user = transmute({
+            homeAddress: { zip: 'bad' },
+            workAddress: { zip: 'bad' }
+        });
+
+        user.updateAsyncRules({ 'root.*.zip': async (value) => /^\d{5}$/.test(value) || 'Zip must be 5 digits' });
+
+        await expect(user.validateAsync()).rejects.toThrowError('Zip must be 5 digits');
+    });
+});

--- a/test/update-model-rules.test.js
+++ b/test/update-model-rules.test.js
@@ -95,4 +95,54 @@ describe('Updating model validation rules', () => {
         expect(() => user.setAge(4)).toThrowError('Updated original rule');
         expect(() => clone.setAge(10)).toThrowError('Original rule');
     });
+
+    test('removeRules() removes one rule while preserving the rest', () => {
+        const user = transmute(
+            { age: 30, name: 'Jane' },
+            {
+                validateInput: true,
+                rules: {
+                    age: (value) => value >= 18 || 'Age rule',
+                    name: (value) => value.length > 0 || 'Name rule'
+                }
+            }
+        );
+
+        const returned = user.removeRules('age');
+
+        expect(returned).toBe(user);
+        expect(() => user.setAge(1)).not.toThrow();
+        expect(() => user.setName('')).toThrowError('Name rule');
+    });
+
+    test('removeRules() accepts multiple keys, including namespaced paths', () => {
+        const user = transmute({ profile: { age: 30 }, name: 'Jane' }, { validateInput: true });
+        user.updateRules({
+            'root.profile.age': (value) => value >= 18 || 'Nested age rule',
+            name: (value) => value.length > 0 || 'Name rule'
+        });
+
+        user.removeRules('root.profile.age', 'name');
+
+        expect(() => user.getProfile().setAge(1)).not.toThrow();
+        expect(() => user.setName('')).not.toThrow();
+    });
+
+    test('updateRules() supports removing rules via the remove option', () => {
+        const user = transmute(
+            { age: 30, name: 'Jane' },
+            {
+                validateInput: true,
+                rules: {
+                    age: (value) => value >= 18 || 'Age rule',
+                    name: (value) => value.length > 0 || 'Name rule'
+                }
+            }
+        );
+
+        user.updateRules({ email: (value) => /@/.test(value) || 'Email rule' }, { mergeRules: true, remove: ['age'] });
+
+        expect(() => user.setAge(1)).not.toThrow();
+        expect(() => user.setName('')).toThrowError('Name rule');
+    });
 });

--- a/test/validation-diagnostics.test.js
+++ b/test/validation-diagnostics.test.js
@@ -1,0 +1,102 @@
+import { describe, expect, test } from '@jest/globals';
+import { transmute } from '../dist/index.js';
+
+describe('Structured validation diagnostics via validate({ collectErrors: true })', () => {
+    test('returns a valid result with no errors when the model is valid', () => {
+        const user = transmute(
+            { age: 25, name: 'ok' },
+            {
+                validateInput: true,
+                rules: { age: (value) => value >= 18 || 'Must be an adult' }
+            }
+        );
+
+        expect(user.validate({ collectErrors: true })).toEqual({ valid: true, errors: [] });
+    });
+
+    test('collects a type mismatch and a rule failure instead of throwing on the first one', () => {
+        // Without validateInput, the setter allows the type to drift; the rule is added afterwards so
+        // updateRules() doesn't revalidate immediately, letting validate() surface both issues together.
+        const user = transmute({ age: 30, name: 'Jane' }, { validateInput: false });
+        user.setAge('not-a-number');
+        user.updateRules({ age: (value) => value >= 18 || 'Must be an adult' });
+
+        const result = user.validate({ collectErrors: true });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ key: 'age', message: expect.stringContaining('Type mismatch') }),
+                expect.objectContaining({ key: 'age', message: 'Validation error [age]: Must be an adult' })
+            ])
+        );
+    });
+
+    test('default validate() call still throws on the first failure (unchanged behavior)', () => {
+        const user = transmute(
+            { age: 15 },
+            {
+                validateInput: true,
+                rules: { age: (value) => value >= 18 || 'Must be an adult' }
+            }
+        );
+
+        expect(() => user.validate()).toThrowError('Must be an adult');
+    });
+
+    test('collects errors from nested objects and array elements with their own paths', () => {
+        const user = transmute(
+            {
+                profile: { age: 15 },
+                contacts: [{ email: 'bad' }, { email: 'ok@techcorp.com' }]
+            },
+            {
+                rules: {
+                    'root.profile.age': (value) => value >= 18 || 'Nested age rule',
+                    email: (value) => /@/.test(value) || 'Email rule'
+                }
+            }
+        );
+
+        const result = user.validate({ collectErrors: true });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ path: 'root.profile.age', message: expect.stringContaining('Nested age rule') }),
+                expect.objectContaining({ key: 'email', message: expect.stringContaining('Email rule') })
+            ])
+        );
+        // Only the first contact fails; the second should not contribute an error.
+        expect(result.errors.filter((e) => e.key === 'email')).toHaveLength(1);
+    });
+
+    test('validateAsync({ collectErrors: true }) collects both sync and async rule failures', async () => {
+        const user = transmute(
+            { age: 15, email: 'bad' },
+            {
+                rules: { age: (value) => value >= 18 || 'Must be an adult' },
+                asyncRules: { email: async (value) => /@/.test(value) || 'Email must contain @' }
+            }
+        );
+
+        const result = await user.validateAsync({ collectErrors: true });
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ key: 'age', message: expect.stringContaining('Must be an adult') }),
+                expect.objectContaining({ key: 'email', message: expect.stringContaining('Email must contain @') })
+            ])
+        );
+    });
+
+    test('validateAsync({ collectErrors: true }) resolves with valid: true when everything passes', async () => {
+        const user = transmute(
+            { email: 'ok@techcorp.com' },
+            { asyncRules: { email: async (value) => /@/.test(value) || 'Email must contain @' } }
+        );
+
+        await expect(user.validateAsync({ collectErrors: true })).resolves.toEqual({ valid: true, errors: [] });
+    });
+});

--- a/test/validation.test.js
+++ b/test/validation.test.js
@@ -67,6 +67,21 @@ describe('Validation and error checks', () => {
         expect(() => o.setArrayAt(3)).toThrowError('Index out of bound!');
     });
 
+    test('Indexed setter validates against the type currently held at that index, even in heterogeneous arrays', () => {
+        // `array` is `['value-2', 456, true]` - one string, one number, one boolean slot.
+        expect(() => o.setArrayAt(0, 999)).toThrowError('Type mismatch: argument of type string expected but got number instead');
+        expect(() => o.setArrayAt(1, 'not-a-number')).toThrowError(
+            'Type mismatch: argument of type number expected but got string instead'
+        );
+        expect(() => o.setArrayAt(2, 'not-a-boolean')).toThrowError(
+            'Type mismatch: argument of type boolean expected but got string instead'
+        );
+
+        expect(() => o.setArrayAt(0, 'value-2-updated')).not.toThrow();
+        expect(() => o.setArrayAt(1, 654)).not.toThrow();
+        expect(() => o.setArrayAt(2, false)).not.toThrow();
+    });
+
     test('validateOnCreate runs the current model graph through validation before returning the model', () => {
         expect(() =>
             transmute(
@@ -108,6 +123,17 @@ describe('Validation and error checks', () => {
             }
         );
         expect(() => invalid.validate()).toThrowError('Must be an adult');
+    });
+
+    test('validate() checks each array element against its originally captured type, even for heterogeneous arrays', () => {
+        const model = transmute({ array: ['value-2', 456, true] }, { validateInput: false });
+        expect(() => model.validate()).not.toThrow();
+
+        // Without validateInput, the setter allows the type drift so validate() must catch it later.
+        model.setArrayAt(0, 999);
+        expect(() => model.validate()).toThrowError(
+            'Type mismatch at index 0 [array]: argument of type string expected but got number instead'
+        );
     });
 
     test('Check invalid input passed to transmute', () => {

--- a/test/validation.test.js
+++ b/test/validation.test.js
@@ -67,6 +67,49 @@ describe('Validation and error checks', () => {
         expect(() => o.setArrayAt(3)).toThrowError('Index out of bound!');
     });
 
+    test('validateOnCreate runs the current model graph through validation before returning the model', () => {
+        expect(() =>
+            transmute(
+                { number: 15 },
+                {
+                    validateOnCreate: true,
+                    rules: {
+                        number: (value) => value >= 18 || 'Must be an adult'
+                    }
+                }
+            )
+        ).toThrowError('Must be an adult');
+    });
+
+    test('validateInput still applies to future setter mutations, not initial construction', () => {
+        const model = transmute({ number: 15 }, { validateInput: true });
+        expect(() => model.setNumber('bad')).toThrowError('Type mismatch: argument of type number expected but got string instead');
+    });
+
+    test('validate() checks the full model state using the current data and rules', () => {
+        const model = transmute(
+            { number: 25, string: 'ok' },
+            {
+                validateInput: true,
+                rules: {
+                    number: (value) => value >= 18 || 'Must be an adult'
+                }
+            }
+        );
+        expect(() => model.validate()).not.toThrow();
+
+        const invalid = transmute(
+            { number: 15, string: 'ok' },
+            {
+                validateInput: true,
+                rules: {
+                    number: (value) => value >= 18 || 'Must be an adult'
+                }
+            }
+        );
+        expect(() => invalid.validate()).toThrowError('Must be an adult');
+    });
+
     test('Check invalid input passed to transmute', () => {
         expect(() => transmute()).toThrowError('Expecting a JavaScript Object notation!');
         expect(() => transmute(null)).toThrowError('Expecting a JavaScript Object notation!');

--- a/test/wildcard-rules.test.js
+++ b/test/wildcard-rules.test.js
@@ -1,0 +1,75 @@
+import { describe, expect, test } from '@jest/globals';
+import { transmute } from '../dist/index.js';
+
+describe('Wildcard and reusable path rules', () => {
+    test('a single "*" segment applies one rule to multiple sibling paths', () => {
+        const user = transmute(
+            {
+                homeAddress: { zip: '00000' },
+                workAddress: { zip: '11111' }
+            },
+            {
+                validateInput: true,
+                rules: {
+                    'root.*.zip': (value) => /^\d{5}$/.test(value) || 'Zip must be 5 digits'
+                }
+            }
+        );
+
+        expect(() => user.getHomeAddress().setZip('bad')).toThrowError('Zip must be 5 digits');
+        expect(() => user.getWorkAddress().setZip('bad')).toThrowError('Zip must be 5 digits');
+        expect(() => user.getHomeAddress().setZip('22222')).not.toThrow();
+        expect(() => user.getWorkAddress().setZip('33333')).not.toThrow();
+    });
+
+    test('an exact namespaced path rule takes precedence over a matching wildcard rule', () => {
+        const user = transmute(
+            {
+                homeAddress: { zip: '00000' },
+                workAddress: { zip: '11111' }
+            },
+            {
+                validateInput: true,
+                rules: {
+                    'root.*.zip': () => 'Generic zip rule',
+                    'root.workAddress.zip': () => 'Work zip rule'
+                }
+            }
+        );
+
+        expect(() => user.getHomeAddress().setZip('22222')).toThrowError('Generic zip rule');
+        expect(() => user.getWorkAddress().setZip('33333')).toThrowError('Work zip rule');
+    });
+
+    test('"*" matches exactly one segment and does not match a different segment count', () => {
+        const user = transmute(
+            {
+                office: { address: { zip: '00000' } }
+            },
+            {
+                validateInput: true,
+                rules: {
+                    'root.*.zip': () => 'Should not match a deeper path'
+                }
+            }
+        );
+
+        expect(() => user.getOffice().getAddress().setZip('anything')).not.toThrow();
+    });
+
+    test('wildcard rules can be added, updated, and removed like any other rule', () => {
+        const user = transmute(
+            {
+                homeAddress: { zip: '00000' },
+                workAddress: { zip: '11111' }
+            },
+            { validateInput: true }
+        );
+
+        user.updateRules({ 'root.*.zip': (value) => /^\d{5}$/.test(value) || 'Zip must be 5 digits' });
+        expect(() => user.getHomeAddress().setZip('bad')).toThrowError('Zip must be 5 digits');
+
+        user.removeRules('root.*.zip');
+        expect(() => user.getHomeAddress().setZip('bad')).not.toThrow();
+    });
+});


### PR DESCRIPTION
Implemented the following as part of validation hardening roadmap:

### P0 — Correctness gaps
- Indexed setters (`setXAt`) now validate the replacement value against the type currently held at that index, instead of skipping type checks entirely. Works correctly for heterogeneous arrays (per-index, not array-wide).
- Added a public `validate()` API to check the full model graph on demand (hydration, imports, bulk mutations, rule updates), not just at setter time.
- Added `validateOnCreate` config option and defined initial-input validation behavior: construction still bypasses setters (to avoid partial-object issues), but `validateOnCreate: true` runs `validate()` immediately after construction.

### P1 — API ergonomics
- Added explicit rule removal: `removeRules(...keys)` and `updateRules(rules, { remove: [...] })`.
- Added wildcard/reusable path rules (e.g. `'root.*.zip'`) so one rule can apply across structurally similar sibling paths, with exact paths still taking precedence.
- Added a minimal async validation path: `Config.asyncRules`, `validateAsync()`, `updateAsyncRules()`, `removeAsyncRules()` — fully separate from the synchronous setter/`rules` path, so existing sync behavior is unaffected.

### P2 — Diagnostics
- Added `validate({ collectErrors: true })` / `validateAsync({ collectErrors: true })`, returning a structured `{ valid, errors }` result (`ValidationIssue[]`) instead of throwing on the first failure. Default calls remain unchanged (fail-fast, throwing).

## Test coverage
New/updated test files: `validation.test.js`, `update-model-rules.test.js`, `wildcard-rules.test.js`, `async-validation.test.js`, `validation-diagnostics.test.js`.

Fixes: #26 