### PR TITLE
feat(validation): improve validator API ergonomics

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,34 @@ export type ValidatorContext = {
 
 export type ValidatorFn = (value: unknown, context: ValidatorContext) => boolean | string;
 
+// Creates a validator that succeeds only when every supplied validator succeeds.
+export const allOf = function (...validators: ValidatorFn[]): ValidatorFn {
+    return (value: unknown, context: ValidatorContext): boolean | string => {
+        for (const validator of validators) {
+            const response = validator(value, context);
+            if (response !== true) {
+                return response;
+            }
+        }
+        return true;
+    };
+};
+
+// Creates a validator that succeeds when at least one supplied validator succeeds.
+export const anyOf = function (...validators: ValidatorFn[]): ValidatorFn {
+    return (value: unknown, context: ValidatorContext): boolean | string => {
+        let lastFailure: boolean | string = false;
+        for (const validator of validators) {
+            const response = validator(value, context);
+            if (response === true) {
+                return true;
+            }
+            lastFailure = response;
+        }
+        return lastFailure;
+    };
+};
+
 export type AsyncValidatorFn = (value: unknown, context: ValidatorContext) => boolean | string | Promise<boolean | string>;
 
 export type Config = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,19 @@ export type ValidatorContext = {
 
 export type ValidatorFn = (value: unknown, context: ValidatorContext) => boolean | string;
 
+export type RuleMetadata = {
+    // Rejects null and undefined values.
+    required?: boolean;
+
+    // Allows the initial value but prevents later setter changes.
+    immutable?: boolean;
+
+    // Applies custom validation alongside the metadata constraints.
+    validator?: ValidatorFn;
+};
+
+export type Rule = ValidatorFn | RuleMetadata;
+
 // Creates a validator that succeeds only when every supplied validator succeeds.
 export const allOf = function (...validators: ValidatorFn[]): ValidatorFn {
     return (value: unknown, context: ValidatorContext): boolean | string => {
@@ -79,7 +92,7 @@ export type Config = {
     validateInput?: boolean;
     validateOnCreate?: boolean;
     cloneable?: boolean;
-    rules?: Record<string, ValidatorFn>;
+    rules?: Record<string, Rule>;
     asyncRules?: Record<string, AsyncValidatorFn>;
 };
 
@@ -113,7 +126,8 @@ type ValidateRuleFn = (
     validator?: ValidatorFn,
     parentObject?: unknown,
     rootObject?: unknown,
-    index?: number
+    index?: number,
+    isUpdate?: boolean
 ) => void;
 
 type ValidateAsyncRuleFn = (
@@ -127,7 +141,7 @@ type ValidateAsyncRuleFn = (
 
 type DynamicClassInstance = IStringIndex & {
     setInternalReferences: (root: unknown, parent: unknown, index?: number) => unknown;
-    updateRules: (rules: Record<string, ValidatorFn>, options?: UpdateRulesOptions) => DynamicClassInstance;
+    updateRules: (rules: Record<string, Rule>, options?: UpdateRulesOptions) => DynamicClassInstance;
     removeRules: (...keys: string[]) => DynamicClassInstance;
     updateAsyncRules: (rules: Record<string, AsyncValidatorFn>, options?: UpdateRulesOptions) => DynamicClassInstance;
     removeAsyncRules: (...keys: string[]) => DynamicClassInstance;
@@ -184,6 +198,8 @@ const findWildcardRuleKey = function <T>(rules: Record<string, T>, nsKey: string
     return Object.keys(rules).find((ruleKey) => ruleKey.includes('*') && matchesWildcardPath(ruleKey, nsKey));
 };
 
+const isRuleMetadata = (rule: Rule | undefined): rule is RuleMetadata => typeof rule === 'object' && rule != null;
+
 /* Validate rule for a property */
 const validateRule = function (
     modelConfig: ModelConfig,
@@ -193,23 +209,53 @@ const validateRule = function (
     validator?: ValidatorFn,
     parentObject?: unknown,
     rootObject?: unknown,
-    index?: number
+    index?: number,
+    isUpdate = false
 ) {
     if (modelConfig.rules != null) {
         const nsKey = nameSpace != null && nameSpace.trim().length > 0 ? `${nameSpace}.${key}` : undefined;
 
         let usedKey = key;
+        let configuredRule: Rule | undefined;
         const contextPath = nameSpace === 'root' ? key : (nsKey ?? key);
         const wildcardKey = nsKey != null ? findWildcardRuleKey(modelConfig.rules, nsKey) : undefined;
         if (nsKey != null && modelConfig.rules[nsKey] != null) {
-            validator = validator ?? modelConfig.rules[nsKey];
+            configuredRule = modelConfig.rules[nsKey];
             usedKey = nsKey;
         } else if (nsKey != null && wildcardKey != null) {
-            validator = validator ?? modelConfig.rules[wildcardKey];
+            configuredRule = modelConfig.rules[wildcardKey];
             usedKey = nsKey;
         } else if (modelConfig.rules[key] != null) {
-            validator = validator ?? modelConfig.rules[key];
+            configuredRule = modelConfig.rules[key];
             usedKey = key;
+        }
+
+        const metadata = isRuleMetadata(configuredRule) ? configuredRule : undefined;
+        validator = validator ?? (typeof configuredRule === 'function' ? configuredRule : metadata?.validator);
+
+        const throwValidationError = (message: string, errorIndex?: number) => {
+            if (errorIndex != null) {
+                throw new Error(`Validation error at index ${errorIndex} [${usedKey}]: ${message}`);
+            }
+            throw new Error(`Validation error [${usedKey}]: ${message}`);
+        };
+
+        if (metadata?.required === true && value == null) {
+            throwValidationError('Value is required', index);
+        }
+
+        // Immutable rules apply only to setter updates so unchanged values remain valid during model validation.
+        if (metadata?.immutable === true && isUpdate) {
+            const getter = `get${capitalize(normalize(key))}`;
+            const currentValue =
+                parentObject != null && typeof parentObject === 'object' && getter in parentObject
+                    ? (parentObject as IStringIndex)[getter]
+                    : undefined;
+            const previousValue = typeof currentValue === 'function' ? (currentValue as () => unknown).call(parentObject) : undefined;
+            const valueToCompare = index != null && Array.isArray(previousValue) ? previousValue[index] : previousValue;
+            if (!Object.is(valueToCompare, value)) {
+                throwValidationError('Property is immutable', index);
+            }
         }
 
         const validate = (v: unknown, i?: number) => {
@@ -690,7 +736,9 @@ const generateDynamicClassInstance = function (
                   v COMMA_PLACEHOLDER 
                   validator COMMA_PLACEHOLDER
                   this COMMA_PLACEHOLDER
-                  this.getRoot()
+                  this.getRoot() COMMA_PLACEHOLDER
+                  undefined COMMA_PLACEHOLDER
+                  true
                 );
                 this.${HASH}${normalize(key)} = v;
                 return this;
@@ -715,7 +763,9 @@ const generateDynamicClassInstance = function (
                       v COMMA_PLACEHOLDER 
                       validator COMMA_PLACEHOLDER
                       this COMMA_PLACEHOLDER
-                      this.getRoot()
+                      this.getRoot() COMMA_PLACEHOLDER
+                      undefined COMMA_PLACEHOLDER
+                      true
                     );
                     this.${HASH}${normalize(key)} = v;
                     return this;
@@ -748,7 +798,8 @@ const generateDynamicClassInstance = function (
                           validator COMMA_PLACEHOLDER
                           this COMMA_PLACEHOLDER
                           this.getRoot() COMMA_PLACEHOLDER
-                          i
+                          i COMMA_PLACEHOLDER
+                          true
                         );
                         this.${HASH}${normalize(key)}[i] = v;
                         return this;
@@ -791,7 +842,8 @@ const generateDynamicClassInstance = function (
                           validator COMMA_PLACEHOLDER
                           this COMMA_PLACEHOLDER
                           this.getRoot() COMMA_PLACEHOLDER
-                          i
+                          i COMMA_PLACEHOLDER
+                          true
                         );
                         value[i] = v;
                         return this;
@@ -946,8 +998,9 @@ const generateDynamicClassInstance = function (
                 validator?: ValidatorFn,
                 parentObject?: unknown,
                 rootObject?: unknown,
-                index?: number
-            ) => validateRule(configForModel, nameSpace, key, value, validator, parentObject, rootObject, index),
+                index?: number,
+                isUpdate?: boolean
+            ) => validateRule(configForModel, nameSpace, key, value, validator, parentObject, rootObject, index, isUpdate),
             validateAsyncRule: (
                 nameSpace: string | undefined,
                 key: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,6 +210,23 @@ const findWildcardRuleKey = function <T>(rules: Record<string, T>, nsKey: string
     return Object.keys(rules).find((ruleKey) => ruleKey.includes('*') && matchesWildcardPath(ruleKey, nsKey));
 };
 
+const resolveConfiguredRule = function <T>(rules: Record<string, T>, nameSpace: string | undefined, key: string, suffix = '') {
+    // Resolve exact, wildcard, and optional [] collection keys while preserving the key used in errors.
+    const namespacedKey = nameSpace != null && nameSpace.trim().length > 0 ? `${nameSpace}.${key}` : undefined;
+    const fullKey = namespacedKey != null ? `${namespacedKey}${suffix}` : `${key}${suffix}`;
+    const wildcardKey = namespacedKey != null ? findWildcardRuleKey(rules, `${namespacedKey}${suffix}`) : undefined;
+    if (namespacedKey != null && rules[`${namespacedKey}${suffix}`] != null) {
+        return { rule: rules[`${namespacedKey}${suffix}`], usedKey: `${namespacedKey}${suffix}` };
+    }
+    if (wildcardKey != null) {
+        return { rule: rules[wildcardKey], usedKey: `${namespacedKey}${suffix}` };
+    }
+    if (rules[`${key}${suffix}`] != null) {
+        return { rule: rules[`${key}${suffix}`], usedKey: `${key}${suffix}` };
+    }
+    return { rule: undefined, usedKey: fullKey };
+};
+
 const isRuleMetadata = (rule: Rule | undefined): rule is RuleMetadata => typeof rule === 'object' && rule != null;
 const isAsyncRuleMetadata = (rule: AsyncRule | undefined): rule is AsyncRuleMetadata => typeof rule === 'object' && rule != null;
 
@@ -228,23 +245,18 @@ const validateRule = function (
     if (modelConfig.rules != null) {
         const nsKey = nameSpace != null && nameSpace.trim().length > 0 ? `${nameSpace}.${key}` : undefined;
 
-        let usedKey = key;
-        let configuredRule: Rule | undefined;
+        // Resolve element and collection rules independently so both can apply to the same array.
+        const elementResolution = resolveConfiguredRule(modelConfig.rules, nameSpace, key);
+        const collectionResolution = resolveConfiguredRule(modelConfig.rules, nameSpace, key, '[]');
+        const usedKey = elementResolution.usedKey;
+        const configuredRule = elementResolution.rule;
+        const collectionRule = collectionResolution.rule;
         const contextPath = nameSpace === 'root' ? key : (nsKey ?? key);
-        const wildcardKey = nsKey != null ? findWildcardRuleKey(modelConfig.rules, nsKey) : undefined;
-        if (nsKey != null && modelConfig.rules[nsKey] != null) {
-            configuredRule = modelConfig.rules[nsKey];
-            usedKey = nsKey;
-        } else if (nsKey != null && wildcardKey != null) {
-            configuredRule = modelConfig.rules[wildcardKey];
-            usedKey = nsKey;
-        } else if (modelConfig.rules[key] != null) {
-            configuredRule = modelConfig.rules[key];
-            usedKey = key;
-        }
 
         const metadata = isRuleMetadata(configuredRule) ? configuredRule : undefined;
         validator = validator ?? (typeof configuredRule === 'function' ? configuredRule : metadata?.validator);
+        const collectionMetadata = isRuleMetadata(collectionRule) ? collectionRule : undefined;
+        const collectionValidator = typeof collectionRule === 'function' ? collectionRule : collectionMetadata?.validator;
 
         const throwValidationError = (message: string, errorIndex?: number) => {
             if (errorIndex != null) {
@@ -301,6 +313,46 @@ const validateRule = function (
             }
         };
 
+        const validateCollection = (collectionValue: unknown) => {
+            if (collectionMetadata?.required === true && collectionValue == null) {
+                throw new Error(`Validation error [${collectionResolution.usedKey}]: Value is required`);
+            }
+            if (collectionValidator == null || collectionValue == null) {
+                return;
+            }
+            const context: ValidatorContext = {
+                key,
+                path: contextPath,
+                value: collectionValue,
+                parentObject,
+                rootObject,
+                // Collection validators inspect the full array, so there is no element index.
+                getParent: () => parentObject,
+                getRoot: () => rootObject
+            };
+            const validationResponse = collectionValidator(collectionValue, context);
+            if (validationResponse !== true) {
+                if (typeof validationResponse === 'string') {
+                    throw new Error(`Validation error [${collectionResolution.usedKey}]: ${validationResponse}`);
+                }
+                throw new Error(`Validation failed for property ${collectionResolution.usedKey} with value ${collectionValue}`);
+            }
+        };
+
+        if (collectionRule != null) {
+            let collectionValue = value;
+            if (index != null && parentObject != null && typeof parentObject === 'object') {
+                // Validate the array state that would exist after an indexed update without mutating it first.
+                const getter = `get${capitalize(normalize(key))}`;
+                const currentValue = (parentObject as IStringIndex)[getter];
+                const currentArray = typeof currentValue === 'function' ? (currentValue as () => unknown[]).call(parentObject) : undefined;
+                if (Array.isArray(currentArray)) {
+                    collectionValue = currentArray.map((item, itemIndex) => (itemIndex === index ? value : item));
+                }
+            }
+            validateCollection(collectionValue);
+        }
+
         if (validator != null && getTypeOfObject(validator) === 'function' && value != null) {
             if (Array.isArray(value)) {
                 value.forEach((v, idx) => validate(v, idx));
@@ -327,30 +379,21 @@ const validateAsyncRule = async function (
 
     const nsKey = nameSpace != null && nameSpace.trim().length > 0 ? `${nameSpace}.${key}` : undefined;
 
-    let usedKey = key;
-    let configuredRule: AsyncRule | undefined;
+    // Resolve element and collection rules independently so both can apply to the same array.
+    const elementResolution = resolveConfiguredRule(modelConfig.asyncRules, nameSpace, key);
+    const collectionResolution = resolveConfiguredRule(modelConfig.asyncRules, nameSpace, key, '[]');
+    const usedKey = elementResolution.usedKey;
+    const configuredRule = elementResolution.rule;
+    const collectionRule = collectionResolution.rule;
     const contextPath = nameSpace === 'root' ? key : (nsKey ?? key);
-    const wildcardKey = nsKey != null ? findWildcardRuleKey(modelConfig.asyncRules, nsKey) : undefined;
-    if (nsKey != null && modelConfig.asyncRules[nsKey] != null) {
-        configuredRule = modelConfig.asyncRules[nsKey];
-        usedKey = nsKey;
-    } else if (nsKey != null && wildcardKey != null) {
-        configuredRule = modelConfig.asyncRules[wildcardKey];
-        usedKey = nsKey;
-    } else if (modelConfig.asyncRules[key] != null) {
-        configuredRule = modelConfig.asyncRules[key];
-        usedKey = key;
-    }
 
     const metadata = isAsyncRuleMetadata(configuredRule) ? configuredRule : undefined;
     const validator = typeof configuredRule === 'function' ? configuredRule : metadata?.validator;
+    const collectionMetadata = isAsyncRuleMetadata(collectionRule) ? collectionRule : undefined;
+    const collectionValidator = typeof collectionRule === 'function' ? collectionRule : collectionMetadata?.validator;
 
     if (metadata?.required === true && value == null) {
         throw new Error(`Validation error [${usedKey}]: Value is required`);
-    }
-
-    if (validator == null) {
-        return;
     }
 
     const validate = async (v: unknown, i?: number) => {
@@ -377,6 +420,41 @@ const validateAsyncRule = async function (
             throw new Error(`Validation failed for property ${usedKey} with value ${v}`);
         }
     };
+
+    const validateCollection = async (collectionValue: unknown) => {
+        if (collectionMetadata?.required === true && collectionValue == null) {
+            throw new Error(`Validation error [${collectionResolution.usedKey}]: Value is required`);
+        }
+        if (collectionValidator == null || collectionValue == null) {
+            return;
+        }
+        const context: ValidatorContext = {
+            key,
+            path: contextPath,
+            value: collectionValue,
+            parentObject,
+            rootObject,
+            // Collection validators inspect the full array, so there is no element index.
+            getParent: () => parentObject,
+            getRoot: () => rootObject
+        };
+        const validationResponse = await collectionValidator(collectionValue, context);
+        if (validationResponse !== true) {
+            if (typeof validationResponse === 'string') {
+                throw new Error(`Validation error [${collectionResolution.usedKey}]: ${validationResponse}`);
+            }
+            throw new Error(`Validation failed for property ${collectionResolution.usedKey} with value ${collectionValue}`);
+        }
+    };
+
+    if (collectionRule != null) {
+        await validateCollection(value);
+    }
+
+    // Collection-only async rules must run before returning when no element rule is configured.
+    if (validator == null) {
+        return;
+    }
 
     if (Array.isArray(value)) {
         for (const [idx, v] of value.entries()) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,12 +88,22 @@ export const anyOf = function (...validators: ValidatorFn[]): ValidatorFn {
 
 export type AsyncValidatorFn = (value: unknown, context: ValidatorContext) => boolean | string | Promise<boolean | string>;
 
+export type AsyncRuleMetadata = {
+    // Rejects null and undefined values during asynchronous validation.
+    required?: boolean;
+
+    // Applies custom synchronous or asynchronous validation.
+    validator?: AsyncValidatorFn;
+};
+
+export type AsyncRule = AsyncValidatorFn | AsyncRuleMetadata;
+
 export type Config = {
     validateInput?: boolean;
     validateOnCreate?: boolean;
     cloneable?: boolean;
     rules?: Record<string, Rule>;
-    asyncRules?: Record<string, AsyncValidatorFn>;
+    asyncRules?: Record<string, AsyncRule>;
 };
 
 export type UpdateRulesOptions = {
@@ -141,9 +151,11 @@ type ValidateAsyncRuleFn = (
 
 type DynamicClassInstance = IStringIndex & {
     setInternalReferences: (root: unknown, parent: unknown, index?: number) => unknown;
+    getRules: () => Record<string, Rule>;
+    getAsyncRules: () => Record<string, AsyncRule>;
     updateRules: (rules: Record<string, Rule>, options?: UpdateRulesOptions) => DynamicClassInstance;
     removeRules: (...keys: string[]) => DynamicClassInstance;
-    updateAsyncRules: (rules: Record<string, AsyncValidatorFn>, options?: UpdateRulesOptions) => DynamicClassInstance;
+    updateAsyncRules: (rules: Record<string, AsyncRule>, options?: UpdateRulesOptions) => DynamicClassInstance;
     removeAsyncRules: (...keys: string[]) => DynamicClassInstance;
     validate: {
         (options?: { collectErrors?: false }): DynamicClassInstance;
@@ -199,6 +211,7 @@ const findWildcardRuleKey = function <T>(rules: Record<string, T>, nsKey: string
 };
 
 const isRuleMetadata = (rule: Rule | undefined): rule is RuleMetadata => typeof rule === 'object' && rule != null;
+const isAsyncRuleMetadata = (rule: AsyncRule | undefined): rule is AsyncRuleMetadata => typeof rule === 'object' && rule != null;
 
 /* Validate rule for a property */
 const validateRule = function (
@@ -315,18 +328,25 @@ const validateAsyncRule = async function (
     const nsKey = nameSpace != null && nameSpace.trim().length > 0 ? `${nameSpace}.${key}` : undefined;
 
     let usedKey = key;
-    let validator: AsyncValidatorFn | undefined;
+    let configuredRule: AsyncRule | undefined;
     const contextPath = nameSpace === 'root' ? key : (nsKey ?? key);
     const wildcardKey = nsKey != null ? findWildcardRuleKey(modelConfig.asyncRules, nsKey) : undefined;
     if (nsKey != null && modelConfig.asyncRules[nsKey] != null) {
-        validator = modelConfig.asyncRules[nsKey];
+        configuredRule = modelConfig.asyncRules[nsKey];
         usedKey = nsKey;
     } else if (nsKey != null && wildcardKey != null) {
-        validator = modelConfig.asyncRules[wildcardKey];
+        configuredRule = modelConfig.asyncRules[wildcardKey];
         usedKey = nsKey;
     } else if (modelConfig.asyncRules[key] != null) {
-        validator = modelConfig.asyncRules[key];
+        configuredRule = modelConfig.asyncRules[key];
         usedKey = key;
+    }
+
+    const metadata = isAsyncRuleMetadata(configuredRule) ? configuredRule : undefined;
+    const validator = typeof configuredRule === 'function' ? configuredRule : metadata?.validator;
+
+    if (metadata?.required === true && value == null) {
+        throw new Error(`Validation error [${usedKey}]: Value is required`);
     }
 
     if (validator == null) {
@@ -894,6 +914,19 @@ const generateDynamicClassInstance = function (
           getIndex() {
             return this.#index;
           }
+
+                    getRules() {
+                        const rules = {};
+                        Object.keys(this.#modelConfig.rules).forEach((key) => {
+                                const rule = this.#modelConfig.rules[key];
+                                rules[key] = rule != null && typeof rule === 'object' ? { ...rule } : rule;
+                        });
+                        return rules;
+                    }
+
+                    getAsyncRules() {
+                        return { ...this.#modelConfig.asyncRules };
+                    }
 
           updateRules(rules, options = {}) {
             const nextRules = options.mergeRules ? { ...this.#modelConfig.rules, ...rules } : { ...rules };

--- a/test/collection-rules.test.js
+++ b/test/collection-rules.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, test } from '@jest/globals';
+import { transmute } from '../dist/index.js';
+
+describe('Collection-level rules', () => {
+    test('runs [] rules against the complete array and regular rules per element', () => {
+        const elementValues = [];
+        const collectionValues = [];
+        const model = transmute(
+            { contacts: ['111', '222'] },
+            {
+                validateInput: true,
+                rules: {
+                    contacts: (value, context) => {
+                        elementValues.push({ value, index: context.index });
+                        return /^\d{3}$/.test(value) || 'Contact must be three digits';
+                    },
+                    'contacts[]': (value, context) => {
+                        collectionValues.push({ value, index: context.index });
+                        return value.length >= 2 || 'At least two contacts are required';
+                    }
+                }
+            }
+        );
+
+        expect(() => model.setContactsAt(0, '333')).not.toThrow();
+        expect(elementValues.at(-1)).toEqual({ value: '333', index: 0 });
+        expect(collectionValues.at(-1)).toEqual({ value: ['333', '222'] });
+        expect(() => model.setContacts(['111'])).toThrowError('At least two contacts are required');
+    });
+
+    test('supports namespaced [] rules for nested arrays', () => {
+        const model = transmute(
+            { profile: { contacts: ['111', '222'] } },
+            {
+                validateInput: true,
+                rules: {
+                    'root.profile.contacts[]': (value) => value.length >= 2 || 'Profile needs two contacts'
+                }
+            }
+        );
+
+        expect(() => model.getProfile().setContacts(['111'])).toThrowError('Profile needs two contacts');
+    });
+
+    test('supports async [] rules during validateAsync()', async () => {
+        const model = transmute(
+            { contacts: ['111'] },
+            {
+                asyncRules: {
+                    'contacts[]': async (value) => value.length >= 2 || 'At least two contacts are required'
+                }
+            }
+        );
+
+        await expect(model.validateAsync()).rejects.toThrowError('At least two contacts are required');
+        model.setContacts(['111', '222']);
+        await expect(model.validateAsync()).resolves.toBe(model);
+    });
+});

--- a/test/composition-helpers.test.js
+++ b/test/composition-helpers.test.js
@@ -1,0 +1,87 @@
+import { allOf, anyOf, transmute } from '../dist/index.js';
+import { describe, expect, test } from '@jest/globals';
+
+const context = {
+    key: 'value',
+    path: 'root.value',
+    value: 'candidate',
+    getParent: () => undefined,
+    getRoot: () => undefined
+};
+
+describe('Validator composition helpers', () => {
+    test('allOf returns the first failure and stops evaluating', () => {
+        const calls = [];
+        const composed = allOf(
+            () => {
+                calls.push('first');
+                return true;
+            },
+            () => {
+                calls.push('second');
+                return 'Second rule failed';
+            },
+            () => {
+                calls.push('third');
+                return true;
+            }
+        );
+
+        expect(composed('candidate', context)).toBe('Second rule failed');
+        expect(calls).toEqual(['first', 'second']);
+        expect(allOf(() => false)('candidate', context)).toBe(false);
+    });
+
+    test('anyOf stops at the first success and returns the last failure otherwise', () => {
+        const calls = [];
+        const composed = anyOf(
+            () => {
+                calls.push('first');
+                return 'First rule failed';
+            },
+            () => {
+                calls.push('second');
+                return true;
+            },
+            () => {
+                calls.push('third');
+                return 'Third rule failed';
+            }
+        );
+
+        expect(composed('candidate', context)).toBe(true);
+        expect(calls).toEqual(['first', 'second']);
+        expect(
+            anyOf(
+                () => 'First failure',
+                () => 'Last failure'
+            )('candidate', context)
+        ).toBe('Last failure');
+    });
+
+    test('empty compositions use boolean identity results', () => {
+        expect(allOf()('candidate', context)).toBe(true);
+        expect(anyOf()('candidate', context)).toBe(false);
+    });
+
+    test('forwards the validator context unchanged through transmute rules', () => {
+        const receivedContexts = [];
+        const model = transmute(
+            { value: 'candidate' },
+            {
+                validateInput: true,
+                rules: {
+                    value: allOf((value, receivedContext) => {
+                        receivedContexts.push(receivedContext);
+                        return value === 'candidate' || 'Unexpected value';
+                    })
+                }
+            }
+        );
+
+        model.setValue('candidate');
+        expect(receivedContexts).toHaveLength(1);
+        expect(receivedContexts[0].path).toBe('value');
+        expect(receivedContexts[0].value).toBe('candidate');
+    });
+});

--- a/test/introspection.test.js
+++ b/test/introspection.test.js
@@ -1,0 +1,52 @@
+import { describe, expect, test } from '@jest/globals';
+import { transmute } from '../dist/index.js';
+
+describe('Rule introspection', () => {
+    test('returns defensive snapshots of synchronous and asynchronous rules', () => {
+        const syncValidator = (value) => value.length > 0 || 'Value is required';
+        const asyncValidator = async (value) => value === 'available' || 'Value is unavailable';
+        const model = transmute(
+            { name: 'Jane', username: 'available' },
+            {
+                rules: {
+                    name: { required: true, validator: syncValidator }
+                },
+                asyncRules: {
+                    username: asyncValidator
+                }
+            }
+        );
+
+        const rules = model.getRules();
+        const asyncRules = model.getAsyncRules();
+
+        expect(rules).toEqual({ name: { required: true, validator: syncValidator } });
+        expect(asyncRules).toEqual({ username: asyncValidator });
+        expect(rules).not.toBe(model.getRules());
+        expect(asyncRules).not.toBe(model.getAsyncRules());
+
+        rules.name.required = false;
+        asyncRules.username = async () => true;
+
+        expect(model.getRules().name.required).toBe(true);
+        expect(model.getAsyncRules().username).toBe(asyncValidator);
+    });
+
+    test('reflects rules added and removed after model creation', () => {
+        const model = transmute({ age: 30 });
+        const ageRule = (value) => value >= 18 || 'Must be an adult';
+        const usernameRule = async (value) => value.length > 2 || 'Username is too short';
+
+        model.updateRules({ age: ageRule });
+        model.updateAsyncRules({ username: usernameRule });
+
+        expect(model.getRules()).toEqual({ age: ageRule });
+        expect(model.getAsyncRules()).toEqual({ username: usernameRule });
+
+        model.removeRules('age');
+        model.removeAsyncRules('username');
+
+        expect(model.getRules()).toEqual({});
+        expect(model.getAsyncRules()).toEqual({});
+    });
+});

--- a/test/rule-metadata.test.js
+++ b/test/rule-metadata.test.js
@@ -72,4 +72,29 @@ describe('Rule metadata', () => {
         expect(() => model.setCode('B-1')).toThrowError('Code must start with A-');
         expect(() => model.setCode('A-2')).not.toThrow();
     });
+
+    test('supports required and custom validators in async rule metadata', async () => {
+        const model = transmute(
+            { username: 'available' },
+            {
+                asyncRules: {
+                    username: {
+                        required: true,
+                        validator: async (value) => value === 'available' || 'Username is unavailable'
+                    }
+                }
+            }
+        );
+
+        await expect(model.validateAsync()).resolves.toBe(model);
+
+        const missing = transmute(
+            { username: null },
+            {
+                asyncRules: { username: { required: true } }
+            }
+        );
+
+        await expect(missing.validateAsync()).rejects.toThrowError('Value is required');
+    });
 });

--- a/test/rule-metadata.test.js
+++ b/test/rule-metadata.test.js
@@ -1,0 +1,75 @@
+import { describe, expect, test } from '@jest/globals';
+import { transmute } from '../dist/index.js';
+
+describe('Rule metadata', () => {
+    test('required rejects null and undefined values', () => {
+        const model = transmute(
+            { name: 'Jane' },
+            {
+                rules: { name: { required: true } }
+            }
+        );
+
+        expect(() => model.setName(null)).toThrowError('Value is required');
+        expect(() => model.setName(undefined)).toThrowError('Value is required');
+    });
+
+    test('required does not reject valid values during construction or validation', () => {
+        const model = transmute(
+            { name: 'Jane' },
+            {
+                validateOnCreate: true,
+                rules: { name: { required: true } }
+            }
+        );
+
+        expect(() => model.validate()).not.toThrow();
+        expect(model.getName()).toBe('Jane');
+    });
+
+    test('immutable allows the initial value but rejects later changes', () => {
+        const model = transmute(
+            { id: 'user-1' },
+            {
+                validateInput: true,
+                validateOnCreate: true,
+                rules: { id: { immutable: true } }
+            }
+        );
+
+        expect(() => model.validate()).not.toThrow();
+        expect(() => model.setId('user-2')).toThrowError('Property is immutable');
+        expect(() => model.setId('user-1')).not.toThrow();
+    });
+
+    test('immutable protects an indexed array element from replacement', () => {
+        const model = transmute(
+            { ids: ['user-1', 'user-2'] },
+            {
+                validateInput: true,
+                rules: { ids: { immutable: true } }
+            }
+        );
+
+        expect(() => model.setIdsAt(0, 'user-3')).toThrowError('Property is immutable');
+        expect(() => model.setIdsAt(0, 'user-1')).not.toThrow();
+    });
+
+    test('metadata can be combined with a custom validator', () => {
+        const model = transmute(
+            { code: 'A-1' },
+            {
+                validateInput: true,
+                rules: {
+                    code: {
+                        required: true,
+                        validator: (value) => String(value).startsWith('A-') || 'Code must start with A-'
+                    }
+                }
+            }
+        );
+
+        expect(() => model.setCode('B-1')).toThrowError('Code must start with A-');
+        expect(() => model.setCode('A-2')).not.toThrow();
+    });
+});


### PR DESCRIPTION
**Summary**

Enhance `Transmute’s` validation API with composable rules, metadata-driven constraints, collection-level validation, asynchronous rule support, and rule introspection.

**Changes**
- Add `allOf` and `anyOf` validator composition helpers.
- Add rule metadata support:
  - required
  - immutable
  - custom validator
- Add async rule metadata with:
  - required
  - async-capable validators
- Add collection-level validators using the [] suffix.
- Preserve per-element validation for unsuffixed array rules.
- Support collection validation during indexed updates using the prospective array state.
- Add synchronous and asynchronous rule introspection through:
  - getRules()
  - getAsyncRules()
- Support namespaced, wildcard, synchronous, and asynchronous collection rules.
- Add focused test coverage for all new validation behavior.
- Update README documentation for the expanded validator API.

**Validation**
- TypeScript compilation passes.
- ESLint passes.
- Full Jest suite passes with 24 suites and 123 tests.

Fixes: #27 