### PR TITLE
docs: expand README and add interactive examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,1043 @@
 # transmute
-Dynamically transform a JSON into a Class with private properties and accessor methods at runtime.
+
+Transform plain JavaScript objects into runtime models with private properties, generated accessors, context-aware validation, cloning, and JSON conversion.
+
+Transmute is useful when data needs a small, predictable model layer without introducing decorators, schemas, or a large runtime framework.
+
+## Features
+
+- Generate getters and setters from object keys.
+- Keep model data in private runtime properties.
+- Validate updates with type checks and custom rules.
+- Run asynchronous rules with `validateAsync()`.
+- Give validators access to the current property, path, parent model, root model, and array index.
+- Express required and immutable constraints with rule metadata.
+- Compose validators with `allOf` and `anyOf`.
+- Validate arrays per element or as complete collections with `[]` rules.
+- Keep configuration and validation rules isolated per model.
+- Update validation rules after transmutation.
+- Inspect registered synchronous and asynchronous rules.
+- Clone models without sharing their data or later rule updates.
+- Convert models back to plain JSON.
+- Support nested objects and arrays of objects.
+- Work in JavaScript and TypeScript projects.
+
+## Installation
+
+```bash
+npm install transmute
+```
+
+With pnpm:
+
+```bash
+pnpm add transmute
+```
+
+## Quick Start
+
+```javascript
+import { transmute } from 'transmute';
+
+const user = transmute({
+	id: 'u-1',
+	name: 'Jane Doe',
+	age: 31,
+	profile: {
+		city: 'Hyderabad'
+	}
+});
+
+console.log(user.getName());
+console.log(user.getProfile().getCity());
+
+user.setName('Jane Smith');
+user.getProfile().setCity('Bengaluru');
+
+console.log(user.toJson());
+```
+
+An optional third argument sets the generated runtime class name, which can help with debugging or developer tools:
+
+```javascript
+const namedUser = transmute({ name: 'Jane Doe' }, undefined, 'User');
+```
+
+Generated methods follow the source property names:
+
+| Input property | Generated methods |
+| --- | --- |
+| `name` | `getName()`, `setName(value)` |
+| `profile` | `getProfile()`, `setProfile(value)` |
+| `contacts` | `getContacts()`, `setContacts(value)` |
+| `contacts` array | `getContactsAt(index)`, `setContactsAt(index, value)` |
+
+Property names are normalized when method names are generated. Spaces, dots, and hyphens are removed or converted so they can be used in JavaScript method names.
+
+## TypeScript
+
+The package exports the public configuration and validator types:
+
+```typescript
+import {
+	AsyncRule,
+	AsyncRuleMetadata,
+	AsyncValidatorFn,
+	Config,
+	Rule,
+	RuleMetadata,
+	UpdateRulesOptions,
+	ValidatorContext,
+	ValidatorFn,
+	ValidationResult,
+	transmute,
+	unTransmute
+} from 'transmute';
+```
+
+The main validator contract is:
+
+```typescript
+type ValidatorFn = (value: unknown, context: ValidatorContext) => boolean | string;
+```
+
+JavaScript functions that declare only the `value` parameter continue to work at runtime because JavaScript ignores additional arguments. TypeScript consumers should use the two-parameter type when assigning validators.
+
+Rules can also be declared as metadata objects. `required` rejects `null` and `undefined`, while `immutable` permits the initial value but rejects later changes through setters. Use `validator` to combine metadata with a custom validation function:
+
+```typescript
+import { transmute } from 'transmute';
+
+const user = transmute(
+	{ id: 'user-1', name: 'Jane Doe' },
+	{
+		validateInput: true,
+		rules: {
+			id: { immutable: true },
+			name: {
+				required: true,
+				validator: (value) => String(value).trim().length > 1 || 'Name is required'
+			}
+		}
+	}
+);
+```
+
+Metadata checks apply during setter validation. Initial construction and full-model validation do not treat an unchanged immutable value as a mutation.
+
+Validators can be composed without repeating the value and context plumbing:
+
+```typescript
+import { allOf, anyOf, transmute } from 'transmute';
+
+const nonEmpty = (value) => String(value).trim().length > 0 || 'Value is required';
+const shortEnough = (value) => String(value).length <= 80 || 'Value is too long';
+const nameRule = allOf(nonEmpty, shortEnough);
+const contactRule = anyOf(
+	(value) => /^\+?[0-9 -]+$/.test(String(value)) || 'Not a phone number',
+	(value) => /^\S+@\S+\.\S+$/.test(String(value)) || 'Not an email address'
+);
+
+const user = transmute({ name: 'Jane Doe', contact: '+91 123 456 7890' }, {
+	validateInput: true,
+	rules: { name: nameRule, contact: contactRule }
+});
+```
+
+`allOf` runs validators in order and returns the first failure, so every rule must pass. `anyOf` returns `true` when any validator succeeds; when all fail, it returns the last failure result. An empty `allOf` succeeds, while an empty `anyOf` fails.
+
+## Where Transmute Fits
+
+Transmute is a runtime model layer for applications where data models are first-class objects. It complements the tools commonly used around a frontend application; it does not replace them.
+
+| Tool | Primary responsibility | How Transmute complements it |
+| --- | --- | --- |
+| TypeScript | Static types during development and compilation | Adds runtime models, accessors, and validation after data exists at runtime. |
+| React | Rendering and component state | Keeps domain behavior and data mutation outside JSX and component event handlers. |
+| Redux | Application-wide state storage and event-driven updates | Stores a Transmute model or its JSON representation when centralized state is needed. |
+| Zod | Schema parsing and input validation | Parses and validates API or form boundaries; Transmute provides the mutable model used after parsing. |
+
+### TypeScript + Transmute
+
+TypeScript describes what a value should look like at compile time. Transmute gives a runtime value generated getters, setters, private properties, and update-time checks.
+
+Use both when data comes from an API, storage, or user input and must remain safe after the initial type boundary:
+
+```typescript
+type UserPayload = {
+	name: string;
+	age: number;
+};
+
+const payload: UserPayload = await fetchUser();
+const user = transmute(payload, { validateInput: true });
+
+user.setAge(32);
+```
+
+TypeScript protects the code that calls `setAge()`. Transmute protects the runtime model when values are changed dynamically.
+
+### React + Transmute
+
+React should describe rendering and user interaction. A Transmute model can own domain updates and validation, while React stores the current model in state and renders its getters.
+
+```jsx
+function ProfileForm({ initialProfile }) {
+	const [profile, setProfile] = React.useState(() =>
+		transmute(initialProfile, {
+			validateInput: true,
+			rules: {
+				name: (value) => String(value).trim().length > 1 || 'Name is required'
+			}
+		})
+	);
+
+	const updateName = (name) => {
+		setProfile((current) => {
+			const next = current.clone();
+			next.setName(name);
+			return next;
+		});
+	};
+
+	return <input value={profile.getName()} onChange={(event) => updateName(event.target.value)} />;
+}
+```
+
+This keeps validation and domain mutation out of the component's rendering logic. For simpler applications, a model can be held directly in component state. For larger applications, the model or `toJson()` output can be integrated with a state store.
+
+### Redux + Transmute
+
+Redux remains responsible for application-wide state, actions, reducers, middleware, and time-travel-friendly state transitions. Transmute is useful at the domain boundary where a Redux slice contains a complex editable entity.
+
+Common approaches include:
+
+- Store plain `toJson()` data in Redux and create a Transmute model at the screen or domain boundary.
+- Store a model when the application already treats the model as a controlled domain object and serialization constraints are understood.
+- Use Redux actions to replace a model snapshot after calling `clone()` and applying validated updates.
+
+For serializable Redux state, prefer storing plain data:
+
+```javascript
+const nextModel = currentModel.clone();
+nextModel.setAge(32);
+
+dispatch({
+	type: 'profile/replaced',
+	payload: nextModel.toJson()
+});
+```
+
+Transmute does not replace Redux. It supplies model behavior at the point where plain state becomes an editable domain object.
+
+### Zod + Transmute
+
+Zod and Transmute solve different parts of the data lifecycle:
+
+1. Use Zod to parse and validate an external boundary such as an API response.
+2. Use the parsed value to create a Transmute model.
+3. Use Transmute setters and context-aware rules during interactive edits.
+4. Use `toJson()` when sending or storing the updated model.
+
+```typescript
+import { z } from 'zod';
+import { transmute } from 'transmute';
+
+const userSchema = z.object({
+	name: z.string(),
+	age: z.number()
+});
+
+const response = await fetch('/api/user');
+const payload = userSchema.parse(await response.json());
+
+const user = transmute(payload, {
+	validateInput: true,
+	rules: {
+		age: (value) => value >= 18 || 'User must be an adult'
+	}
+});
+```
+
+Zod is a strong choice for parsing unknown external data and producing typed results. Transmute is a strong choice for the mutable, accessor-based model that lives after parsing. They can be used together without duplicating responsibility.
+
+### Where It Fits Best
+
+Transmute is a good fit when an application has:
+
+- Editable forms with repeated updates to the same entity.
+- Nested domain objects that need discoverable getters and setters.
+- Cross-property rules such as confirmation fields or date ranges.
+- API data that needs behavior after hydration.
+- Optimistic updates implemented by cloning a model before mutation.
+- Model-specific rules that must remain isolated from other entities.
+- A preference for small runtime abstractions over a full state or schema framework.
+
+Transmute is less suitable when an application only needs:
+
+- Static TypeScript types with no runtime mutation checks.
+- One-time parsing of external data, where a schema library is sufficient.
+- A global state workflow that should contain only serializable plain objects.
+- Immutable state transitions with no need for model methods.
+
+### Advantages of First-Class Models
+
+Treating models as first-class citizens can provide:
+
+- **Encapsulation:** Consumers use generated accessors instead of reaching into arbitrary object shapes.
+- **Consistent mutation:** Setters provide one place for type checks and custom validation.
+- **Local domain behavior:** Cross-property rules live close to the model they protect.
+- **Object-graph context:** Validators can inspect siblings, parents, the root model, paths, and array indexes.
+- **Configuration isolation:** Models do not inherit rules from models created later.
+- **Predictable cloning:** A clone gets independent data and a configuration snapshot.
+- **Framework flexibility:** The model can be used from React, Redux integrations, hooks, services, or plain JavaScript.
+- **Serialization boundaries:** Runtime behavior stays on the model while `toJson()` produces plain data for APIs and storage.
+
+The central tradeoff is that models are runtime objects rather than plain serializable data. Applications should serialize them at state, persistence, and network boundaries when those systems require plain values.
+
+For more detailed use cases, see the [Examples](#examples) section.
+
+## Configuration
+
+`transmute()` accepts optional configuration:
+
+```typescript
+type Config = {
+	validateInput?: boolean;
+	validateOnCreate?: boolean;
+	cloneable?: boolean;
+	rules?: Record<string, Rule>;
+	asyncRules?: Record<string, AsyncRule>;
+};
+```
+
+Defaults:
+
+```text
+validateInput: false
+validateOnCreate: false
+cloneable: true
+rules: {}
+asyncRules: {}
+```
+
+Example:
+
+```javascript
+const user = transmute(
+	{
+		name: 'Jane Doe',
+		age: 31
+	},
+	{
+		validateInput: true,
+		cloneable: true,
+		rules: {
+			name: (value, context) => String(value).trim().length > 1 || 'Name is required',
+			age: (value, context) => Number(value) >= 18 || 'Age must be at least 18'
+		}
+	}
+);
+```
+
+Configuration is scoped to the model created by that `transmute()` call. Creating another model does not replace the first model's rules or clone behavior.
+
+## Validation
+
+The library separates mutation validation from creation-time validation:
+
+- `validateInput: true` enables validation for all subsequent setter-based mutations.
+- `validateOnCreate: true` validates the initial payload once the object graph is fully constructed.
+- `model.validate()` validates the current model state at any time.
+
+This keeps validation predictable during hydration while still protecting future writes. Creation-time validation evaluates the current model graph and any rules attached to it; it does not infer a new schema from raw input.
+
+### Mutation Validation
+
+Validation is enabled with `validateInput: true`:
+
+When enabled, Transmute performs built-in runtime type validation for setter values even when no custom `rules` are provided. Custom rules extend this with application-specific checks such as formats, ranges, and cross-property constraints.
+
+```javascript
+const user = transmute(
+	{ email: 'jane@example.com' },
+	{
+		validateInput: true,
+		rules: {
+			email: (value, context) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(value)) || 'Invalid email'
+		}
+	}
+);
+
+user.setEmail('invalid');
+// Throws: Validation error [email]: Invalid email
+```
+
+Setters validate before changing the stored value. If validation fails, the previous value remains unchanged.
+
+Validation is fail-fast by default: the first failing setter or array-element update throws an error. For form or diagnostics workflows, pass `{ collectErrors: true }` to collect failures instead:
+
+```javascript
+const result = user.validate({ collectErrors: true });
+
+if (!result.valid) {
+	console.log(result.errors);
+}
+```
+
+Each error includes the failing `path`, property `key`, human-readable `message`, and an `index` when the failure belongs to an array element. The asynchronous equivalent is `await user.validateAsync({ collectErrors: true })`.
+
+### Creation-Time Validation
+
+Use `validateOnCreate: true` when you want the initial model graph to be checked against its current values and rules before the model is returned:
+
+```javascript
+const user = transmute(
+	{ age: 15 },
+	{
+		validateInput: true,
+		validateOnCreate: true,
+		rules: {
+			age: (value) => value >= 18 || 'Must be an adult'
+		}
+	}
+);
+// Throws: Validation error [age]: Must be an adult
+```
+
+This is useful for imported data and hydration flows where a model should be checked immediately after construction.
+
+### Full-Model Validation
+
+You can validate the complete model state at any time with `validate()`:
+
+```javascript
+const user = transmute(
+	{ age: 31, email: 'jane@example.com' },
+	{
+		validateInput: true,
+		rules: {
+			age: (value) => value >= 18 || 'Age must be at least 18'
+		}
+	}
+);
+
+user.validate();
+```
+
+`validate()` walks the current model graph, reuses the current setter validation rules, and throws on the first failure. It is intended for hydration, imported data, and post-update verification of the current graph.
+
+### Asynchronous Validation
+
+Use `asyncRules` for checks that require an asynchronous operation, such as checking username availability against a service. Asynchronous rules do not run during synchronous setters or `validate()`; call `validateAsync()` explicitly:
+
+```javascript
+const user = transmute(
+	{ username: 'jane-doe' },
+	{
+		asyncRules: {
+			username: async (value) => {
+				const response = await fetch(`/api/users/${encodeURIComponent(value)}/availability`);
+				return response.ok || 'Username is already in use';
+			}
+		}
+	}
+);
+
+await user.validateAsync();
+```
+
+`validateAsync()` runs synchronous type and rule checks first, then awaits asynchronous rules across the complete nested object graph, including array elements. It resolves to the model when valid and rejects with the validation error when invalid. Async metadata supports `required` and an async-capable `validator`:
+
+```javascript
+const profile = transmute(
+	{ username: 'jane-doe' },
+	{
+		asyncRules: {
+			username: {
+				required: true,
+				validator: async (value) => value.length >= 3 || 'Username is too short'
+			}
+		}
+	}
+);
+
+await profile.validateAsync();
+```
+
+Asynchronous rules are useful at save or submission boundaries when the result depends on a remote system. Keep local, deterministic checks in `rules` so setters can reject invalid edits immediately.
+
+`validateOnCreate` performs synchronous creation-time validation. If asynchronous creation-time checks are required, construct the model and call `await model.validateAsync()` at the application boundary.
+
+### Canonical Workflow
+
+A practical app flow is:
+
+1. Hydrate a model from API or persisted data.
+2. Optionally run `validateOnCreate` or `model.validate()` immediately after hydration.
+3. Clone the live model before a user edit if you want an easy rollback path.
+4. Edit using generated setters.
+5. Validate again before persisting.
+6. Roll back to the last committed snapshot if the save fails.
+
+```javascript
+let model = transmute(await fetchProfile(), {
+	validateInput: true,
+	validateOnCreate: true,
+	rules: {
+		age: (value) => value >= 18 || 'Age must be at least 18',
+		email: (value) => /\S+@\S+\.\S+/.test(String(value)) || 'Invalid email'
+	}
+});
+
+const snapshot = model.clone();
+
+try {
+	model.setAge(17);
+	model.validate();
+	await saveProfile(unTransmute(model));
+} catch (error) {
+	model = snapshot;
+	throw error;
+}
+```
+
+Transmute stores model values in private fields, so rollback replaces the working model reference instead of using `Object.assign()`. This pattern keeps the domain logic on the model while letting the application boundary remain simple: fetch, validate, mutate, persist, and roll back on failure.
+
+### Built-in Type Validation
+
+Built-in type validation does not require custom rules. Transmute remembers the type of each input property and checks setter values when `validateInput` is enabled:
+
+```javascript
+const user = transmute(
+	{
+		name: 'Jane Doe',
+		age: 31,
+		active: true,
+		contacts: ['+91-99999-99999']
+	},
+	{ validateInput: true }
+);
+
+user.setAge(32); // Valid
+user.setActive(false); // Valid
+user.setContacts(['+91-88888-88888']); // Valid
+
+user.setAge('32');
+// Throws: Type mismatch: argument of type number expected but got string instead
+
+user.setContacts('not-an-array');
+// Throws: Type mismatch: argument of type array expected but got string instead
+```
+
+A failed type check leaves the previous property value unchanged. Use custom rules when validation needs formats, ranges, or relationships between properties.
+
+### Validation Results
+
+Validators return:
+
+- `true` when the value is valid.
+- A string containing the validation message when the value is invalid.
+- Any other non-`true` value for a generic validation failure.
+
+```javascript
+const rules = {
+	age: (value, context) => value >= 18 || 'Age must be at least 18',
+	status: (value, context) => ['draft', 'active'].includes(value) || 'Invalid status'
+};
+```
+
+### Rule Metadata and Collection Rules
+
+Rules may be plain validator functions or metadata objects. Metadata is useful when a property needs a built-in constraint together with an optional custom validator:
+
+```javascript
+const user = transmute(
+	{ id: 'user-1', name: 'Jane Doe' },
+	{
+		validateInput: true,
+		rules: {
+			id: { immutable: true },
+			name: {
+				required: true,
+				validator: (value) => String(value).trim().length > 1 || 'Name is required'
+			}
+		}
+	}
+);
+```
+
+- `required` rejects `null` and `undefined` during the applicable validation pass.
+- `immutable` allows the initial value but rejects later setter changes. It is a synchronous setter constraint.
+- `validator` applies custom synchronous validation alongside the metadata constraints.
+- `asyncRules` uses the same registration model for asynchronous validators, with `required` and an async-capable `validator`.
+
+Array rules have two scopes. An unsuffixed key validates each element, while a key ending in `[]` validates the complete collection:
+
+```javascript
+const directory = transmute(
+	{ contacts: ['+91-11111-11111', '+91-22222-22222'] },
+	{
+		validateInput: true,
+		rules: {
+			contacts: (value) => /^\+?[0-9-]+$/.test(value) || 'Invalid contact number',
+			'contacts[]': (value) => value.length >= 2 || 'At least two contacts are required'
+		}
+	}
+);
+```
+
+Both rules run when both are configured. `contacts` receives one element and an `index` in its `ValidatorContext`; `contacts[]` receives the complete array and no element index. On `setContactsAt(index, value)`, the collection rule validates the prospective array with the candidate value in place, before the model is mutated. The same `[]` convention works with namespaced and asynchronous rules, such as `root.profile.contacts[]` in `asyncRules`.
+
+### Context-Aware Validation
+
+Every validator receives the value and a `ValidatorContext`:
+
+```typescript
+type ValidatorContext = {
+	key: string;
+	path: string;
+	value: unknown;
+	parentObject?: unknown;
+	rootObject?: unknown;
+	index?: number;
+	getParent: () => unknown;
+	getRoot: () => unknown;
+};
+```
+
+The context enables rules that depend on more than the value being updated.
+
+#### Sibling Validation
+
+```javascript
+const account = transmute(
+	{
+		password: 'secret123',
+		confirmPassword: 'secret123'
+	},
+	{
+		validateInput: true,
+		rules: {
+			confirmPassword: (value, context) => {
+				const password = context.parentObject.getPassword();
+				return password === value || 'Passwords do not match';
+			}
+		}
+	}
+);
+```
+
+#### Root-Level Validation
+
+```javascript
+const order = transmute(
+	{
+		customer: { country: 'US' },
+		shipping: { country: 'US' }
+	},
+	{
+		validateInput: true,
+		rules: {
+			'root.shipping.country': (value, context) => {
+				const customerCountry = context.getRoot().getCustomer().getCountry();
+				return value === customerCountry || 'Shipping country does not match customer country';
+			}
+		}
+	}
+);
+```
+
+#### Conditional Validation
+
+Conditional rules can be expressed inline by returning `true` when the condition does not apply. This keeps the existing `ValidatorFn` contract and gives the validator access to sibling or parent state:
+
+```javascript
+const customer = transmute(
+	{
+		country: 'IN',
+		taxId: ''
+	},
+	{
+		validateInput: true,
+		rules: {
+			taxId: (value, context) => {
+				const country = context.getParent().getCountry();
+				return country !== 'US' || /^[0-9]{9}$/.test(String(value)) || 'Invalid US tax ID';
+			}
+		}
+	}
+);
+
+customer.setCountry('US');
+customer.setTaxId('123456789');
+```
+
+When the country is not `US`, the rule succeeds without applying the tax ID format. When the country is `US`, the format check runs normally. The same pattern works with root state, nested models, array indexes, and `[]` collection rules.
+
+#### Array-Index Validation
+
+```javascript
+const user = transmute(
+	{
+		contacts: ['primary', 'secondary']
+	},
+	{
+		validateInput: true,
+		rules: {
+			contacts: (value, context) => {
+				if (context.index === 0 && value !== 'primary') {
+					return 'The first contact must be primary';
+				}
+				return true;
+			}
+		}
+	}
+);
+
+user.setContactsAt(0, 'secondary');
+```
+
+#### Rule Paths
+
+Rules can target a fully qualified path:
+
+```javascript
+const profile = transmute(
+	{
+		profile: {
+			age: 30
+		}
+	},
+	{
+		validateInput: true,
+		rules: {
+			'root.profile.age': (value, context) => value >= 18 || `Invalid value at ${context.path}`
+		}
+	}
+);
+```
+
+Rules can also use a leaf key such as `age` or `email`. A fully qualified rule is preferred when it is present.
+
+Wildcard paths can apply one rule to matching segments at any depth of a namespaced path. Use `*` for exactly one path segment:
+
+```javascript
+const company = transmute(
+	{
+		homeAddress: { zip: '500001' },
+		workAddress: { zip: '500002' }
+	},
+	{
+		validateInput: true,
+		rules: {
+			'root.*.zip': (value) => /^\d{6}$/.test(String(value)) || 'ZIP code must have six digits'
+		}
+	}
+);
+
+company.getHomeAddress().setZip('invalid');
+```
+
+The same wildcard matching is available in `asyncRules`. Exact namespaced rules take precedence over matching wildcard rules.
+
+## Updating Rules
+
+Models expose `updateRules()` for explicit runtime rule changes:
+
+```typescript
+type UpdateRulesOptions = {
+	mergeRules?: boolean;
+	remove?: string[];
+};
+```
+
+By default, the supplied rules replace the current rule set:
+
+```javascript
+user.updateRules({
+	age: (value, context) => value >= 21 || 'Age must be at least 21'
+});
+```
+
+Use `mergeRules: true` to preserve existing rules and add or overwrite only the supplied rules:
+
+```javascript
+user.updateRules(
+	{
+		email: (value, context) => String(value).includes('@') || 'Invalid email'
+	},
+	{ mergeRules: true }
+);
+```
+
+Rules are copied when updated, so later mutations to the caller's rules object do not change the model. Updates apply to future setter calls only; existing values are not automatically revalidated.
+
+Calling `updateRules()` on a nested model updates the shared model configuration and returns the root model:
+
+```javascript
+const root = user.getProfile().updateRules({
+	'root.profile.age': (value, context) => value >= 18 || 'Age must be at least 18'
+});
+
+root.setName('Updated name');
+```
+
+Remove synchronous rules with `removeRules()` or with the `remove` option on `updateRules()`:
+
+```javascript
+user.removeRules('age');
+
+user.updateRules(
+	{ email: (value) => String(value).includes('@') || 'Invalid email' },
+	{ mergeRules: true, remove: ['name'] }
+);
+```
+
+Asynchronous rules have matching update and removal methods. They are kept separate from synchronous rules because they run only through `validateAsync()`:
+
+```javascript
+user.updateAsyncRules({
+	username: async (value) => value !== 'taken' || 'Username is unavailable'
+});
+
+user.updateAsyncRules(
+	{ email: async (value) => String(value).includes('@') || 'Invalid email' },
+	{ mergeRules: true }
+);
+
+user.removeAsyncRules('username');
+```
+
+Use `getRules()` and `getAsyncRules()` to inspect the currently registered rule maps. The returned maps are snapshots, so changing them does not change model validation:
+
+```javascript
+const rules = user.getRules();
+const asyncRules = user.getAsyncRules();
+
+console.log(Object.keys(rules));
+console.log(Object.keys(asyncRules));
+```
+
+Introspection is useful for dynamic forms, debugging, and showing which validation policies apply to a model. It reports configured rules; it does not execute validators or analyze their function bodies.
+
+## Nested Objects and Arrays
+
+Nested plain objects become nested models:
+
+```javascript
+const user = transmute({
+	profile: {
+		city: 'Hyderabad',
+		active: true
+	}
+});
+
+user.getProfile().setCity('Bengaluru');
+```
+
+Arrays of primitives support indexed access:
+
+```javascript
+const user = transmute({
+	contacts: ['+91-99999-99999', '+91-88888-88888']
+});
+
+user.setContactsAt(0, '+91-77777-77777');
+console.log(user.getContactsAt(0));
+```
+
+Arrays of objects produce indexed nested models:
+
+```javascript
+const company = transmute({
+	employees: [
+		{ id: 'E-1', name: 'Alice' },
+		{ id: 'E-2', name: 'Bob' }
+	]
+});
+
+company.getEmployeesAt(0).setName('Alice Smith');
+```
+
+Model configuration is shared by nested objects and array elements belonging to the same root model.
+
+Use `getMetaInfo()` when tooling needs to inspect which source properties are primitive values, nested objects, or arrays. It returns model-shape metadata, not validation rules; use `getRules()` and `getAsyncRules()` for rule introspection.
+
+## Cloning
+
+Cloning creates a new model from the current JSON data:
+
+```javascript
+const original = transmute(
+	{ name: 'Jane', age: 31 },
+	{
+		validateInput: true,
+		rules: {
+			age: (value, context) => value >= 18 || 'Age must be at least 18'
+		}
+	}
+);
+
+const copy = original.clone();
+copy.setName('Janet');
+
+console.log(original.getName());
+console.log(copy.getName());
+```
+
+The original and clone do not share model data. The clone receives a snapshot of the configuration and rules at clone time. Later rule updates on the original do not affect an existing clone.
+
+Disable cloning when it is not needed:
+
+```javascript
+const model = transmute(data, { cloneable: false });
+console.log(model.clone); // undefined
+```
+
+## JSON Conversion
+
+`toJson()` returns a plain object containing model data:
+
+```javascript
+const plainObject = user.toJson();
+```
+
+`unTransmute()` accepts a model or an array of models:
+
+```javascript
+import { unTransmute } from 'transmute';
+
+const plainUser = unTransmute(user);
+const plainUsers = unTransmute([userA, userB]);
+```
+
+Runtime metadata such as private properties, parent/root references, rules, and configuration is not included in the output.
+
+`JSON.stringify(model)` intentionally does not serialize the model as data. Use `model.toJson()` or `unTransmute(model)` when JSON output is required.
+
+## Utility API
+
+### `memorySizeOf`
+
+Estimate the encoded size of a JSON-compatible object:
+
+```javascript
+import { memorySizeOf } from 'transmute';
+
+console.log(memorySizeOf(user.toJson()));
+```
+
+The result is formatted in bytes, KiB, MiB, or GiB.
+
+## Error Handling
+
+Type mismatches are rejected by generated setters:
+
+```javascript
+const user = transmute({ age: 31 }, { validateInput: true });
+
+user.setAge('31');
+// Type mismatch: argument of type number expected but got string instead
+```
+
+Validation errors include the rule path and, for indexed updates, the array index:
+
+```text
+Validation error at index 1 [root.items.id]: Duplicate ID: ITEM-1
+```
+
+Validator exceptions are not swallowed. If a validator throws its own exception, that exception propagates to the caller.
+
+## Construction and Updates
+
+Transmute separates model construction from public updates:
+
+1. Input values are assigned through internal initialization methods.
+2. Nested models and array elements are generated recursively.
+3. Root, parent, and array-index metadata are attached.
+4. Public setters validate only subsequent updates.
+
+This prevents context-aware validators from running against a partially constructed object graph.
+
+## Limitations
+
+- Multidimensional arrays are not supported.
+- Validation is fail-fast by default. Use `validate({ collectErrors: true })` or `validateAsync({ collectErrors: true })` to collect multiple failures.
+- Existing values are not revalidated automatically after `updateRules()`.
+- `updateRules()` changes rules only; `validateInput` and `cloneable` are structural options selected when the model is generated.
+- Validator functions are runtime functions and are not serialized by `toJson()`.
+- Property names that normalize to the same generated method name can collide.
+- TypeScript consumers should use the two-argument validator signature even when a rule does not need the context.
+
+## Examples
+
+The repository includes polished interactive demos in [`examples/`](examples/):
+
+- `01-type-validation` — built-in runtime type validation without custom rules.
+- `02-context-aware-validation` — sibling and cross-field validation with `ValidatorContext`.
+- `03-dynamic-model-rules` — per-model rule isolation, replacement, merging, and cloning.
+- `04-full-form-flow` — editable form state, fail-fast validation, cloning, and payload logging.
+- `05-validation-ergonomics` — focused demos of `allOf`, rule metadata, `[]` collection validators,
+  asynchronous validation, and rule introspection.
+- `06-user-directory` — nested user-directory models, adapters, and runtime rule changes.
+
+To run the browser examples from a repository checkout, using npm:
+
+```bash
+npm run build:dev
+node examples/server.js
+```
+
+Then open:
+
+```text
+http://localhost:4173/
+```
+
+The examples server serves the generated `dist` modules and the reference example pages. The examples are not included in the published package.
+
+## Development
+
+Install development dependencies and build the library with npm:
+
+```bash
+npm install
+npm run build:dev
+```
+
+Run the test suite:
+
+```bash
+npm test -- --runInBand
+```
+
+Run linting:
+
+```bash
+npm run lint
+```
+
+Create a production-oriented build with minification:
+
+```bash
+npm run build
+```
+
+The build emits CommonJS, ESM, IIFE, and TypeScript declaration files under `dist/`. The `dist` directory is generated and should not be edited manually or committed.
+
+## Release Notes
+
+The context-aware validator API is a breaking TypeScript API change when upgrading from a value-only `ValidatorFn` type. JavaScript functions that declare only one parameter continue to work at runtime, but TypeScript validators should use:
+
+```typescript
+const rule: ValidatorFn = (value, context) => {
+	return value !== '' || 'Value is required';
+};
+```
+
+Per-model configuration and runtime rule updates are designed to prevent configuration leakage between models. `updateRules()` uses replacement by default; merging must be requested explicitly with `{ mergeRules: true }`.
+
+## License
+
+MIT

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -58,5 +58,16 @@ export default [
                 }
             ]
         }
+    },
+    {
+        // In-browser demos load React/ReactDOM from a CDN and the library UMD bundle as globals.
+        files: ['examples/**/*.js', 'examples/**/*.jsx'],
+        languageOptions: {
+            globals: {
+                React: 'readonly',
+                ReactDOM: 'readonly',
+                lib: 'readonly'
+            }
+        }
     }
 ];

--- a/examples/01-type-validation/index.html
+++ b/examples/01-type-validation/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Built-in Type Validation</title>
+    <link rel="stylesheet" href="../styles.css" />
+</head>
+
+<body>
+    <main>
+        <header>
+            <div class="back-breadcrumb"><a class="back" href="/">&larr; Examples</a> / Type Validation</div>
+            <h1>Guard the shape first.</h1>
+            <p>See how generated setters enforce baseline runtime types before any custom rules are introduced.</p>
+        </header>
+        <div id="root">
+            <p>Loading demo...</p>
+        </div>
+    </main>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/babel-standalone@6.26.0/babel.js"></script>
+    <script src="/dist/index.global.js"></script>
+    <script type="text/babel" src="src/main.js"></script>
+</body>
+
+</html>

--- a/examples/01-type-validation/src/main.js
+++ b/examples/01-type-validation/src/main.js
@@ -1,0 +1,52 @@
+const { transmute } = lib.api;
+
+function App() {
+    const [model, setModel] = React.useState(() =>
+        transmute(
+            {
+                name: 'Jane Doe',
+                age: 31,
+                active: true,
+                contacts: ['+91-99999-99999']
+            },
+            { validateInput: true }
+        )
+    );
+    const [message, setMessage] = React.useState('Try a valid or invalid update.');
+    const run = (update) => {
+        const next = model.clone();
+        try {
+            update(next);
+            setModel(next);
+            setMessage('Update accepted.');
+        } catch (error) {
+            setMessage(error);
+        }
+    };
+
+    console.log('[01-type-validation] model', model.toJson());
+    return (
+        <div>
+            <ol>
+                <li>
+                    Setting <code>validateInput</code> to true enables built-in type validation.
+                </li>
+                <li>The model will throw an error if a field is set to a value of the wrong type.</li>
+                <li>If an error is thrown, the model will remain unchanged.</li>
+            </ol>
+            <div>Try the buttons below to see how the model reacts to valid and invalid updates.</div>
+            <br />
+            <div className="button-group">
+                <button onClick={() => run((m) => m.setAge(32))}>Set age as number</button>
+                <button onClick={() => run((m) => m.setAge('32'))}>Set age as text</button>
+                <button onClick={() => run((m) => m.setActive(false))}>Set active as boolean</button>
+                <button onClick={() => run((m) => m.setContacts('not an array'))}>Set contacts as text</button>
+            </div>
+            <p className={message.startsWith('Update') ? 'ok' : 'error'}>{message}</p>
+            <pre>{JSON.stringify(model.toJson(), null, 2)}</pre>
+        </div>
+    );
+}
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(React.createElement(React.StrictMode, null, React.createElement(App)));

--- a/examples/02-context-aware-validation/index.html
+++ b/examples/02-context-aware-validation/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Context-aware Validation</title>
+    <link rel="stylesheet" href="../styles.css" />
+</head>
+
+<body>
+    <main>
+        <header>
+            <div class="back-breadcrumb"><a class="back" href="/">&larr; Examples</a> / Context-aware Rules</div>
+            <h1>Rules with field awareness.</h1>
+            <p>Validate cross-field relationships by reading sibling values through the validator context object.</p>
+        </header>
+        <div id="root">
+            <p>Loading demo...</p>
+        </div>
+    </main>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/babel-standalone@6.26.0/babel.js"></script>
+    <script src="/dist/index.global.js"></script>
+    <script type="text/babel" src="./src/main.js"></script>
+</body>
+
+</html>

--- a/examples/02-context-aware-validation/src/main.js
+++ b/examples/02-context-aware-validation/src/main.js
@@ -1,0 +1,54 @@
+const { transmute } = lib.api;
+
+function App() {
+    const [model, setModel] = React.useState(() =>
+        transmute(
+            {
+                password: 'secret123',
+                confirmPassword: 'secret123',
+                startDate: '2025-01-01',
+                endDate: '2025-01-31'
+            },
+            {
+                validateInput: true,
+                rules: {
+                    confirmPassword: (value, context) => value === context.parentObject.getPassword() || 'Passwords do not match',
+                    endDate: (value, context) => value >= context.parentObject.getStartDate() || 'End date must be after start date'
+                }
+            }
+        )
+    );
+    const [error, setError] = React.useState('');
+    const update = (fn) => {
+        const next = model.clone();
+        try {
+            fn(next);
+            setModel(next);
+            setError('');
+        } catch (e) {
+            setError(e.message);
+        }
+    };
+    return (
+        <div>
+            <p>
+                Validators can inspect sibling fields through <code>context.parentObject</code>.
+            </p>
+            <label>
+                Confirmation <input defaultValue="wrong" id="confirm" />
+            </label>
+            <button onClick={() => update((m) => m.setConfirmPassword(document.getElementById('confirm').value))}>
+                Validate confirmation
+            </button>
+            <label>
+                End date <input defaultValue="2024-01-01" id="end" />
+            </label>
+            <button onClick={() => update((m) => m.setEndDate(document.getElementById('end').value))}>Validate date range</button>
+            <p className="error">{error}</p>
+            <pre>{JSON.stringify(model.toJson(), null, 2)}</pre>
+        </div>
+    );
+}
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(React.createElement(React.StrictMode, null, React.createElement(App)));

--- a/examples/03-dynamic-model-rules/index.html
+++ b/examples/03-dynamic-model-rules/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Dynamic Model Rules</title>
+  <link rel="stylesheet" href="../styles.css" />
+</head>
+
+<body>
+    <main>
+      <header>
+        <div class="back-breadcrumb"><a class="back" href="/">&larr; Examples</a> / Runtime Rule Updates</div>
+        <h1>Change rules per model.</h1>
+        <p>Explore isolated rule sets, explicit merge behavior, and safe cloning across model instances.</p>
+      </header>
+      <div id="root">
+          <p>Loading demo...</p>
+      </div>
+  </main>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6.26.0/babel.js"></script>
+  <script src="/dist/index.global.js"></script>
+  <script type="text/babel" src="./src/main.js"></script>
+</body>
+
+</html>

--- a/examples/03-dynamic-model-rules/src/main.js
+++ b/examples/03-dynamic-model-rules/src/main.js
@@ -1,0 +1,61 @@
+const { transmute } = lib.api;
+
+const ageRule = (value) => value >= 18 || 'Age must be at least 18';
+const nameRule = (value) => String(value).length >= 3 || 'Name must have at least 3 characters';
+const makeModel = (name) => transmute({ name, age: 30 }, { validateInput: true, rules: { age: ageRule } });
+
+function Card({ label, model, refresh, setClone }) {
+    const [message, setMessage] = React.useState('');
+    const act = (fn) => {
+        try {
+            fn(model);
+            setMessage('Accepted');
+            refresh();
+        } catch (e) {
+            setMessage(e.message);
+        }
+    };
+    return (
+        <article>
+            <h2>{label}</h2>
+            <p>
+                Name: {model.getName()} · Age: {model.getAge()}
+            </p>
+            <div className="button-group">
+                <button onClick={() => act((m) => m.updateRules({ name: nameRule }, { mergeRules: true }))}>Merge name rule</button>
+                <button onClick={() => act((m) => m.updateRules({ name: nameRule }))}>Replace rules</button>
+                <button onClick={() => act((m) => m.setName('Al'))}>Try short name</button>
+                <button onClick={() => setClone(model.clone())}>Clone</button>
+            </div>
+            <p className="error">{message}</p>
+            <pre>{JSON.stringify(model.toJson(), null, 2)}</pre>
+        </article>
+    );
+}
+
+function App() {
+    const [, refresh] = React.useState(0);
+    const [first] = React.useState(() => makeModel('Alice'));
+    const [second] = React.useState(() => makeModel('Bob'));
+    const [clone, setClone] = React.useState(null);
+    return (
+        <div>
+            <div>
+                <p>Each model has isolated rules. Merge is explicit; replacement is the default.</p>
+                <div className="grid">
+                    <Card label="Model A" model={first} refresh={() => refresh((n) => n + 1)} setClone={setClone}></Card>
+                    <Card label="Model B" model={second} refresh={() => refresh((n) => n + 1)} setClone={setClone}></Card>
+                </div>
+                {clone && (
+                    <div>
+                        <h2>Latest clone</h2>
+                        <pre>{JSON.stringify(clone.toJson(), null, 2)}</pre>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(React.createElement(React.StrictMode, null, React.createElement(App)));

--- a/examples/04-full-form-flow/index.html
+++ b/examples/04-full-form-flow/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Full Form Flow</title>
+  <link rel="stylesheet" href="../styles.css" />
+</head>
+
+<body>
+    <main>
+      <header>
+        <div class="back-breadcrumb"><a class="back" href="/">&larr; Examples</a> / Form Lifecycle</div>
+        <h1>Edit, validate, ship payload.</h1>
+        <p>Walk through an end-to-end form loop where each field update is validated before persistence.</p>
+      </header>
+      <div id="root">
+          <p>Loading demo...</p>
+      </div>
+  </main>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6.26.0/babel.js"></script>
+  <script src="/dist/index.global.js"></script>
+  <script type="text/babel" src="./src/main.js"></script>
+</body>
+
+</html>

--- a/examples/04-full-form-flow/src/api.js
+++ b/examples/04-full-form-flow/src/api.js
@@ -1,0 +1,4 @@
+export async function saveProfile(payload) {
+    console.log('[04-full-form-flow] save payload', payload);
+    return { ok: true, saved: payload };
+}

--- a/examples/04-full-form-flow/src/main.js
+++ b/examples/04-full-form-flow/src/main.js
@@ -1,0 +1,65 @@
+const { transmute } = lib.api;
+
+const createModel = () =>
+    transmute(
+        {
+            name: 'Jane Doe',
+            email: 'jane.doe@example.com',
+            company: 'Northstar Labs',
+            age: 31
+        },
+        {
+            validateInput: true,
+            rules: {
+                name: (value) => String(value).trim().length > 1 || 'Name is required',
+                email: (value) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value) || 'Invalid email',
+                company: (value) => String(value).trim().length > 1 || 'Company is required',
+                age: (value) => value >= 18 || 'Age must be 18 or more'
+            }
+        }
+    );
+
+function App() {
+    const [model, setModel] = React.useState(() => createModel());
+    const [error, setError] = React.useState('');
+    const update = (field, value) => {
+        const next = model.clone();
+        try {
+            next[`set${field[0].toUpperCase()}${field.slice(1)}`](value);
+            setModel(next);
+            setError('');
+        } catch (e) {
+            setError(e.message);
+        }
+    };
+
+    return (
+        <div>
+            <div>
+                <p>Edit a model, see validation at the field boundary, then inspect the payload sent to an API.</p>
+                <label>
+                    Name
+                    <input value={model.getName()} onChange={(e) => update('name', e.target.value)} />
+                </label>
+                <label>
+                    Email
+                    <input value={model.getEmail()} onChange={(e) => update('email', e.target.value)} />
+                </label>
+                <label>
+                    Company
+                    <input value={model.getCompany()} onChange={(e) => update('company', e.target.value)} />
+                </label>
+                <label>
+                    Age
+                    <input type="number" value={model.getAge()} onChange={(e) => update('age', Number(e.target.value))} />
+                </label>
+                <p className="error">{error}</p>
+                <button onClick={() => console.log('[04-full-form-flow] submit payload', model.toJson())}>Save and log payload</button>
+                <pre>{JSON.stringify(model.toJson(), null, 2)}</pre>
+            </div>
+        </div>
+    );
+}
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(React.createElement(React.StrictMode, null, React.createElement(App)));

--- a/examples/04-full-form-flow/src/model.js
+++ b/examples/04-full-form-flow/src/model.js
@@ -1,0 +1,16 @@
+import { transmute } from '../../../dist/index.mjs';
+
+export function createProfileModel(payload) {
+    return transmute(
+        payload,
+        {
+            validateInput: true,
+            rules: {
+                name: (value) => String(value).trim().length > 1 || 'Name is required',
+                email: (value) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value) || 'Invalid email',
+                age: (value) => value >= 18 || 'Age must be 18 or more'
+            }
+        },
+        'Profile'
+    );
+}

--- a/examples/05-validation-ergonomics/index.html
+++ b/examples/05-validation-ergonomics/index.html
@@ -1,0 +1,127 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Validation Ergonomics</title>
+    <link rel="stylesheet" href="../styles.css" />
+</head>
+
+<body>
+    <main>
+        <header>
+        <div class="back-breadcrumb"><a class="back" href="/">&larr; Examples</a> / Validation Ergonomics</div>
+            <h1>Small rules, clear intent.</h1>
+            <p>Explore the validation ergonomics: compose reusable checks, protect metadata, validate
+                a whole collection, and inspect asynchronous rules.</p>
+        </header>
+        <div class="grid">
+            <div class="fixed-list">
+                <section class="wide paddingTopZero">
+                    <h2>Current model JSON</h2>
+                    <pre id="model-json"></pre>
+                </section>
+                <section class="wide paddingTopZero">
+                    <h2>Current rules</h2>
+                    <pre id="rules-json">
+{
+  rules: {
+    id: { immutable: true },
+    name: {
+      required: true,
+      validator: (value) => {
+        return String(value).trim().length > 2
+          || 'Name must be longer than two characters';
+      }
+    },
+    password: allOf(
+      (value) => {
+        return String(value).trim().length > 0
+          || 'Password is required';
+        },
+        (value) => {
+          return String(value).length >= 8
+            || 'Password must be at least 8 characters';
+        }
+    ),
+    contacts: (value) => {
+      return phonePattern.test(String(value))
+        || 'Contact must be of format +CC-XXXXX-XXXXX';
+    },
+    'contacts[]': (value) => {
+      return value.length >= 2
+        || 'At least two contacts are required';
+    },
+  },
+  asyncRules: {
+    username: async (value) => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1500);
+      });
+      return value !== 'existing-name'
+        || 'Username is already taken';
+    }
+  }
+}
+                    </pre>
+                </section>
+            </div>
+            <div class="fixed-list scrollable">
+                <section class="sectionWithBorder">
+                    <p class="eyebrow">01 / composition</p>
+                    <h2>All of these checks</h2>
+                    <p class="note">The password rule combines presence and length with <code>allOf</code>.</p>
+                    <input id="password" type="password" value="1234567" />
+                    <div class="actions"><button id="check-password">Run allOf</button></div>
+                    <p id="password-status" class="status" aria-live="polite"></p>
+                </section>
+                <section class="sectionWithBorder">
+                    <p class="eyebrow">02 / metadata</p>
+                    <h2>Constraints as data</h2>
+                    <p class="note">The ID is immutable; the name is required and custom-validated.</p>
+                    <label class="label" for="name">Name</label>
+                    <input id="name" value="Ada Lovelace" />
+                    <div class="actions">
+                        <button id="update-name">Update name</button>
+                        <button id="change-id" class="secondary">Attempt ID change</button>
+                    </div>
+                    <p id="metadata-status" class="status" aria-live="polite"></p>
+                </section>
+                <section class="sectionWithBorder">
+                    <p class="eyebrow">03 / collection scope</p>
+                    <h2>Element or array?</h2>
+                    <p class="note">The unsuffixed rule checks each phone. The <code>[]</code> rule checks the complete
+                        collection.</p>
+                    <label class="label" for="update-contact-1">Contact #1</label>
+                    <input id="contact-1" value="+91-33333-33333" />
+                    <label class="label" for="contact-2">Contact #2</label>
+                    <input id="contact-2" value="+91-44444-44444" />
+                    <div class="actions">
+                        <button id="update-contact-1">Update #1</button>
+                        <button id="update-contact-2">Update #2</button>
+                        <button id="update-both-contacts" class="secondary">Update both</button>
+                    </div>
+                    <p id="collection-status" class="status" aria-live="polite"></p>
+                </section>
+                <section class="sectionWithBorder">
+                    <p class="eyebrow">04 / async + introspection</p>
+                    <h2>Before the boundary</h2>
+                    <p class="note">The simulated remote rule runs only through <code>validateAsync()</code>.</p>
+                    <label class="label" for="username">Username</label>
+                    <input id="username" value="existing-name" />
+                    <div class="actions">
+                        <button id="run-async">Validate asynchronously</button>
+                        <button id="inspect" class="secondary">Inspect rules</button>
+                    </div>
+                    <p id="async-status" class="status" aria-live="polite"></p>
+                    <pre id="inspection">No rule snapshot requested yet.</pre>
+                </section>
+            </div>
+        </div>
+    </main>
+    <script src="/dist/index.global.js"></script>
+    <script src="./src/main.js"></script>
+</body>
+
+</html>

--- a/examples/05-validation-ergonomics/src/main.js
+++ b/examples/05-validation-ergonomics/src/main.js
@@ -1,0 +1,109 @@
+const { allOf, transmute } = lib.api;
+
+const phonePattern = /^\+?[0-9]{2,3}-[0-9]{5}-[0-9]{5}$/;
+
+const model = transmute(
+    {
+        id: 'user-001',
+        name: 'Ada Lovelace',
+        password: 'transmute',
+        contacts: ['+91-11111-11111', '+91-22222-22222'],
+        username: 'ada-lovelace'
+    },
+    {
+        validateInput: true,
+        rules: {
+            id: { immutable: true },
+            name: {
+                required: true,
+                validator: (value) => String(value).trim().length > 2 || 'Name must be longer than two characters'
+            },
+            password: allOf(
+                (value) => String(value).trim().length > 0 || 'Password is required',
+                (value) => String(value).length >= 8 || 'Password must be at least 8 characters'
+            ),
+            contacts: (value) => phonePattern.test(String(value)) || 'Contact must be of format +CC-XXXXX-XXXXX',
+            'contacts[]': (value) => value.length >= 2 || 'At least two contacts are required'
+        },
+        asyncRules: {
+            username: async (value) => {
+                await new Promise((resolve) => setTimeout(resolve, 1500));
+                return value !== 'existing-name' || 'Username is already taken';
+            }
+        }
+    },
+    'ValidationErgonomics'
+);
+
+console.log(model.getRules());
+console.log(model.getAsyncRules());
+
+const text = (id) => document.getElementById(id);
+const setStatus = (id, message, error = false) => {
+    const node = text(id);
+    node.textContent = message;
+    node.classList.toggle('error', error);
+};
+const refresh = () => {
+    text('model-json').textContent = JSON.stringify(model.toJson(), null, 2);
+};
+const attempt = (statusId, callback) => {
+    try {
+        callback();
+        setStatus(statusId, 'Update accepted.');
+        refresh();
+    } catch (error) {
+        setStatus(statusId, error.message, true);
+    }
+};
+
+text('check-password').addEventListener('click', () => {
+    attempt('password-status', () => model.setPassword(text('password').value));
+});
+
+text('update-name').addEventListener('click', () => {
+    attempt('metadata-status', () => model.setName(text('name').value));
+});
+
+text('change-id').addEventListener('click', () => {
+    attempt('metadata-status', () => model.setId('user-002'));
+});
+
+text('update-contact-1').addEventListener('click', () => {
+    attempt('collection-status', () => model.setContactsAt(0, text('contact-1').value));
+});
+
+text('update-contact-2').addEventListener('click', () => {
+    attempt('collection-status', () => model.setContactsAt(1, text('contact-2').value));
+});
+
+text('update-both-contacts').addEventListener('click', () => {
+    attempt('collection-status', () => {
+        model.setContacts([text('contact-1').value, text('contact-2').value].filter((str) => str.trim() !== ''));
+    });
+});
+
+text('run-async').addEventListener('click', async () => {
+    setStatus('async-status', 'Checking remote availability...');
+    try {
+        model.setUsername(text('username').value);
+        await model.validateAsync();
+        setStatus('async-status', 'Async validation passed.');
+        refresh();
+    } catch (error) {
+        setStatus('async-status', error.message, true);
+    }
+});
+
+text('inspect').addEventListener('click', () => {
+    text('inspection').textContent = JSON.stringify(
+        {
+            syncRuleKeys: Object.keys(model.getRules()),
+            asyncRuleKeys: Object.keys(model.getAsyncRules())
+        },
+        null,
+        2
+    );
+});
+
+refresh();

--- a/examples/06-user-directory/index.html
+++ b/examples/06-user-directory/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>User Directory</title>
+    <link rel="stylesheet" href="../styles.css" />
+</head>
+
+<body>
+    <main>
+        <header>
+            <div class="back-breadcrumb"><a class="back" href="/">&larr; Examples</a> / Full App</div>
+            <h1>User directory in production shape.</h1>
+            <p>Combine adapters, dynamic rules, optimistic updates, and rollback in a realistic end-to-end flow.</p>
+        </header>
+        <div id="root">
+            <p>Loading demo...</p>
+        </div>
+    </main>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/babel-standalone@6.26.0/babel.js"></script>
+    <script src="/dist/index.global.js"></script>
+    <script type="text/babel" src="src/model.js"></script>
+    <script type="text/babel" src="src/adapters.js"></script>
+    <script type="text/babel" src="src/api.js"></script>
+    <script type="text/babel" src="src/useUserDirectory.js"></script>
+    <script type="text/babel" src="src/main.js"></script>
+</body>
+
+</html>

--- a/examples/06-user-directory/src/adapters.js
+++ b/examples/06-user-directory/src/adapters.js
@@ -1,0 +1,12 @@
+// Adapter boundary: keeps transmute model instances out of the network/api layer.
+function toUserModel(raw) {
+    return window.UD.createUserModel(raw);
+}
+
+function fromUserModel(model) {
+    return model.toJson();
+}
+
+window.UD = window.UD || {};
+window.UD.toUserModel = toUserModel;
+window.UD.fromUserModel = fromUserModel;

--- a/examples/06-user-directory/src/api.js
+++ b/examples/06-user-directory/src/api.js
@@ -1,0 +1,65 @@
+// Simulated backend: an in-memory directory with artificial latency and a server-side rule.
+const NETWORK_DELAY_MS = 350;
+
+let directory = [
+    {
+        id: 'u-1',
+        name: 'Jane Doe',
+        email: 'jane@example.com',
+        age: 31,
+        status: 'active',
+        contacts: ['+91-99999-99999', '080-1234-5678'],
+        profile: { city: 'Hyderabad', score: 91 }
+    },
+    {
+        id: 'u-2',
+        name: 'Asha Gupta',
+        email: 'asha@example.com',
+        age: 29,
+        status: 'draft',
+        contacts: ['+91-90000-00000'],
+        profile: { city: 'Pune', score: 76 }
+    },
+    {
+        id: 'u-3',
+        name: 'Shreya Iyer',
+        email: 'shreya@example.com',
+        age: 26,
+        status: 'archived',
+        contacts: ['+91-80000-00000', '044-2222-3333'],
+        profile: { city: 'Chennai', score: 88 }
+    }
+];
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function fetchUsers() {
+    await wait(NETWORK_DELAY_MS);
+    return directory.map((user) => ({ ...user }));
+}
+
+async function fetchUser(id) {
+    await wait(NETWORK_DELAY_MS);
+    const found = directory.find((user) => user.id === id);
+    if (!found) {
+        throw new Error(`User ${id} not found`);
+    }
+    return { ...found };
+}
+
+async function saveUser(id, payload) {
+    await wait(NETWORK_DELAY_MS);
+
+    // Server-side check that the client model doesn't enforce, to show the API boundary rejecting bad data too.
+    if (payload.profile && Number(payload.profile.score) < 0) {
+        throw new Error('Server rejected update: score cannot be negative');
+    }
+
+    directory = directory.map((user) => (user.id === id ? { ...payload, id } : user));
+    return { ...payload, id, savedAt: new Date().toISOString() };
+}
+
+window.UD = window.UD || {};
+window.UD.fetchUsers = fetchUsers;
+window.UD.fetchUser = fetchUser;
+window.UD.saveUser = saveUser;

--- a/examples/06-user-directory/src/main.js
+++ b/examples/06-user-directory/src/main.js
@@ -1,0 +1,124 @@
+const { useUserDirectory } = window.UD;
+
+function App() {
+    const {
+        users,
+        selectedId,
+        model,
+        strict,
+        status,
+        fieldError,
+        banner,
+        selectUser,
+        updateField,
+        updateProfileField,
+        updateContact,
+        toggleStrict,
+        save
+    } = useUserDirectory();
+
+    return (
+        <div>
+            {!model ? (
+                <section>
+                    <p>Loading directory...</p>
+                </section>
+            ) : (
+                <div className="layout">
+                    <aside>
+                        <h2>Directory</h2>
+                        <br />
+                        <ul className="user-list">
+                            {users.map((user) => (
+                                <li key={user.id}>
+                                    <button className={user.id === selectedId ? 'selected' : ''} onClick={() => selectUser(user.id)}>
+                                        {user.name}
+                                        <span className="badge">{user.status}</span>
+                                    </button>
+                                </li>
+                            ))}
+                        </ul>
+                    </aside>
+
+                    <section className="paddingTopZero">
+                        <p className="marginTopZero">
+                            A full flow built on <code>transmute</code>: hydrate a model from the API, edit it via accessor methods with
+                            built-in and context-aware validation, toggle dynamic rules, then save through an adapter layer with optimistic
+                            updates and rollback on server rejection.
+                        </p>
+
+                        <div className="grid">
+                            <div className="grid-item">
+                                <label>
+                                    Name
+                                    <input value={model.getName()} onChange={(e) => updateField('setName', e.target.value)} />
+                                </label>
+                                <label>
+                                    Email
+                                    <input value={model.getEmail()} onChange={(e) => updateField('setEmail', e.target.value)} />
+                                </label>
+                                <label>
+                                    Age
+                                    <input
+                                        type="number"
+                                        value={model.getAge()}
+                                        onChange={(e) => updateField('setAge', Number(e.target.value))}
+                                    />
+                                </label>
+                                <label>
+                                    Status
+                                    <select value={model.getStatus()} onChange={(e) => updateField('setStatus', e.target.value)}>
+                                        <option value="draft">draft</option>
+                                        <option value="active">active</option>
+                                        <option value="archived">archived</option>
+                                    </select>
+                                </label>
+                            </div>
+                            <div className="grid-item">
+                                <label>
+                                    City
+                                    <input
+                                        value={model.getProfile().getCity()}
+                                        onChange={(e) => updateProfileField('setCity', e.target.value)}
+                                    />
+                                </label>
+                                <label>
+                                    Score (only positive values allowed)
+                                    <input
+                                        type="number"
+                                        value={model.getProfile().getScore()}
+                                        onChange={(e) => updateProfileField('setScore', Number(e.target.value))}
+                                    />
+                                </label>
+
+                                {model.toJson().contacts.map((_, index) => (
+                                    <label key={index}>
+                                        {`Contact #${index + 1} (must start with +)`}
+                                        <input value={model.getContactsAt(index)} onChange={(e) => updateContact(index, e.target.value)} />
+                                    </label>
+                                ))}
+                            </div>
+                        </div>
+                        <div>
+                            <div className="rules-panel">
+                                <button onClick={save} disabled={status === 'saving'}>
+                                    {status === 'saving' ? 'Saving...' : 'Save to server'}
+                                </button>
+                                <button onClick={toggleStrict}>{strict ? 'Reset to base rules' : 'Merge strict rules'}</button>
+                                <span className="badge">{strict ? 'strict rules merged' : 'base rules only'}</span>
+                            </div>
+                        </div>
+                        <p className="error">{fieldError}</p>
+                        <p className={status === 'error' ? 'error' : 'ok'}>{banner}</p>
+
+                        <h3>Debug</h3>
+                        <pre>{JSON.stringify({ toJson: model.toJson(), metaInfo: model.getMetaInfo() }, null, 2)}</pre>
+                    </section>
+                </div>
+            )}
+        </div>
+    );
+}
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(React.createElement(React.StrictMode, null, React.createElement(App)));

--- a/examples/06-user-directory/src/model.js
+++ b/examples/06-user-directory/src/model.js
@@ -1,0 +1,27 @@
+const { transmute } = lib.api;
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// Rules shared by every directory user model; contacts[0] is treated as the primary number.
+const baseRules = {
+    name: (value) => String(value).trim().length > 1 || 'Name is required',
+    email: (value) => EMAIL_PATTERN.test(String(value)) || 'Invalid email format',
+    age: (value) => Number(value) >= 18 || 'Age must be 18 or more',
+    status: (value) => ['draft', 'active', 'archived'].includes(value) || 'Invalid status',
+    contacts: (value, context) => context.index !== 0 || String(value).startsWith('+') || 'Primary contact must start with +'
+};
+
+// Opt-in rules merged over baseRules via updateRules() to demonstrate runtime rule changes.
+const strictRules = {
+    name: (value) => String(value).trim().length >= 3 || 'Name must have at least 3 characters',
+    email: (value) => (EMAIL_PATTERN.test(String(value)) && String(value).split('@')[1].includes('.')) || 'Email domain looks incomplete'
+};
+
+function createUserModel(payload) {
+    return transmute(payload, { validateInput: true, rules: baseRules }, 'DirectoryUser');
+}
+
+window.UD = window.UD || {};
+window.UD.baseRules = baseRules;
+window.UD.strictRules = strictRules;
+window.UD.createUserModel = createUserModel;

--- a/examples/06-user-directory/src/useUserDirectory.js
+++ b/examples/06-user-directory/src/useUserDirectory.js
@@ -1,0 +1,115 @@
+const { useCallback, useEffect, useRef, useState } = React;
+
+// Custom hook combining fetch-hydration, clone-based edits, dynamic rule toggling and optimistic save/rollback.
+function useUserDirectory() {
+    const [users, setUsers] = useState([]);
+    const [selectedId, setSelectedId] = useState(null);
+    const [model, setModel] = useState(null);
+    const [strict, setStrict] = useState(false);
+    const [status, setStatus] = useState('idle');
+    const [fieldError, setFieldError] = useState('');
+    const [banner, setBanner] = useState('');
+    const lastSyncedRef = useRef(null);
+
+    const selectUser = useCallback((id) => {
+        setStatus('loading');
+        setFieldError('');
+        setBanner('');
+        window.UD.fetchUser(id).then((raw) => {
+            const hydrated = window.UD.toUserModel(raw);
+            lastSyncedRef.current = hydrated;
+            setSelectedId(id);
+            setModel(hydrated.clone());
+            setStrict(false);
+            setStatus('idle');
+        });
+    }, []);
+
+    useEffect(() => {
+        window.UD.fetchUsers().then((list) => {
+            setUsers(list);
+            if (list.length > 0) {
+                selectUser(list[0].id);
+            }
+        });
+    }, [selectUser]);
+
+    const applyToClone = useCallback((mutator) => {
+        setModel((current) => {
+            if (!current) {
+                return current;
+            }
+            const next = current.clone();
+            try {
+                mutator(next);
+                setFieldError('');
+                return next;
+            } catch (error) {
+                setFieldError(error.message || String(error));
+                return current;
+            }
+        });
+    }, []);
+
+    const updateField = useCallback((setterName, value) => applyToClone((next) => next[setterName](value)), [applyToClone]);
+
+    const updateProfileField = useCallback(
+        (setterName, value) => applyToClone((next) => next.getProfile()[setterName](value)),
+        [applyToClone]
+    );
+
+    const updateContact = useCallback((index, value) => applyToClone((next) => next.setContactsAt(index, value)), [applyToClone]);
+
+    const toggleStrict = useCallback(() => {
+        setModel((current) => {
+            if (!current) {
+                return current;
+            }
+            const nowStrict = !strict;
+            current.updateRules(nowStrict ? window.UD.strictRules : window.UD.baseRules, { mergeRules: nowStrict });
+            setStrict(nowStrict);
+            setBanner(nowStrict ? 'Merged stricter name/email rules onto the model.' : 'Reset to base rules only.');
+            return current.clone();
+        });
+    }, [strict]);
+
+    const save = useCallback(async () => {
+        if (!model || !selectedId) {
+            return;
+        }
+        setStatus('saving');
+        setBanner('');
+        try {
+            const payload = window.UD.fromUserModel(model);
+            const saved = await window.UD.saveUser(selectedId, payload);
+            setUsers((list) => list.map((user) => (user.id === selectedId ? { ...saved } : user)));
+            lastSyncedRef.current = window.UD.toUserModel(saved);
+            setStatus('saved');
+            setBanner(`Saved at ${saved.savedAt}`);
+        } catch (error) {
+            // Roll back the optimistic edits to the last known-good server state.
+            setModel(lastSyncedRef.current.clone());
+            setStatus('error');
+            setBanner(error.message || String(error));
+        }
+    }, [model, selectedId]);
+
+    return {
+        users,
+        selectedId,
+        model,
+        strict,
+        status,
+        fieldError,
+        banner,
+        selectUser,
+        updateField,
+        updateProfileField,
+        updateContact,
+        toggleStrict,
+        save
+    };
+}
+
+window.UD = window.UD || {};
+window.UD.useUserDirectory = useUserDirectory;

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,37 @@
+# Transmute Examples
+
+The examples folder contains polished interactive demos of the library's main runtime behaviors. Start the examples server from the repository root:
+
+```bash
+npm run build:dev
+node examples/server.js
+```
+
+Open `http://localhost:4173/` and use the hub to launch a demo.
+
+## Interactive demos
+
+- `01-type-validation` — built-in type validation without custom rules.
+- `02-context-aware-validation` — sibling and cross-field validation using `ValidatorContext`.
+- `03-dynamic-model-rules` — per-model rule isolation, replacement, merging, and cloning.
+- `04-full-form-flow` — editable form state, fail-fast validation, cloning, and payload logging.
+- `05-validation-ergonomics` — focused demos of `allOf`, rule metadata, `[]` collection validators,
+  asynchronous validation, and rule introspection.
+- `06-user-directory` — a consolidated, full-blown app combining every core capability: fetch-and-hydrate,
+  built-in and context-aware validation, dynamic rule merging/replacement, an adapter layer at the API
+  boundary, a custom data hook, and optimistic save with server-side rollback.
+
+## Canonical workflow
+
+The recommended app lifecycle across the examples is:
+
+1. Hydrate a model from an API or storage adapter.
+2. Validate it immediately using `validateOnCreate` or `model.validate()`.
+3. Clone the current model before user edits for optimistic rollback.
+4. Edit through generated setters while rules enforce both type and domain constraints.
+5. Persist the plain JSON payload with `unTransmute()` after validation passes.
+6. Restore the previous snapshot if the save fails.
+
+This workflow is the basis of the full-form and user-directory demos and is the easiest way to integrate Transmute into existing application state and API boundaries.
+
+Note: The examples intentionally load React and Babel from CDNs in browser demos. They are reference applications, not distributable packages or production build configurations.

--- a/examples/app.js
+++ b/examples/app.js
@@ -1,0 +1,30 @@
+console.log('[examples] Booting examples index page');
+
+fetch('/api/examples')
+    .then((response) => response.json())
+    .then((examples) => {
+        const list = document.getElementById('example-list');
+
+        console.log('[examples] Loaded examples from server:', examples);
+
+        if (!list) {
+            return;
+        }
+
+        list.innerHTML = examples
+            .map(
+                (example) =>
+                    `<li>
+                <a href="${example.path}">${example.title}</a>
+            </li>`
+            )
+            .join('');
+    })
+    .catch((error) => {
+        const list = document.getElementById('example-list');
+        console.error('[examples] Failed to load examples:', error);
+
+        if (list) {
+            list.innerHTML = `<li>Unable to load examples: ${error.message}</li>`;
+        }
+    });

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Transmute Examples</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <main>
+      <header>
+        <p class="eyebrow">Transmute Demo Gallery</p>
+        <h1>Choose an example.</h1>
+        <p>Each route focuses on one capability, from baseline type validation to a full application flow.</p>
+      </header>
+      <section class="paddingTopZero">
+        <ul id="example-list" class="example-list">
+          <li><a href="/01-type-validation/">1. Built-in Type Validation</a></li>
+          <li><a href="/02-context-aware-validation/">2. Context-aware Validation</a></li>
+          <li><a href="/03-dynamic-model-rules/">3. Dynamic Model Rules</a></li>
+          <li><a href="/04-full-form-flow/">4. Full Form Flow</a></li>
+          <li><a href="/05-validation-ergonomics/">5. Validation Ergonomics</a></li>
+          <li><a href="/06-user-directory/">6. User Directory (Full App)</a></li>
+        </ul>
+      </section>
+    </main>
+  </body>
+</html>

--- a/examples/server.js
+++ b/examples/server.js
@@ -1,0 +1,172 @@
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+import { URL } from 'url';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = __dirname;
+const DIST_ROOT = path.resolve(ROOT, '..', 'dist');
+const PORT = Number(process.env.PORT || 4173);
+
+const MIME_TYPES = {
+    '.html': 'text/html; charset=utf-8',
+    '.js': 'application/javascript; charset=utf-8',
+    '.mjs': 'application/javascript; charset=utf-8',
+    '.jsx': 'application/javascript; charset=utf-8',
+    '.cjs': 'application/javascript; charset=utf-8',
+    '.css': 'text/css; charset=utf-8',
+    '.json': 'application/json; charset=utf-8',
+    '.svg': 'image/svg+xml',
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.ico': 'image/x-icon',
+    '.txt': 'text/plain; charset=utf-8'
+};
+
+function toTitle(folderName) {
+    return folderName.replace(/-/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function listExamples() {
+    return fs
+        .readdirSync(ROOT, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory() && !entry.name.startsWith('.') && entry.name !== 'snippets')
+        .map((entry) => ({
+            name: entry.name,
+            title: toTitle(entry.name),
+            path: `/${entry.name}/`
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function isWithinRoot(targetPath) {
+    const rootPath = path.resolve(ROOT);
+    const resolved = path.resolve(targetPath);
+    return resolved === rootPath || resolved.startsWith(rootPath + path.sep);
+}
+
+function sendJson(res, payload) {
+    res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+    res.end(JSON.stringify(payload));
+}
+
+function sendFile(res, filePath) {
+    const ext = path.extname(filePath).toLowerCase();
+    const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+
+    fs.readFile(filePath, (error, buffer) => {
+        if (error) {
+            res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+            res.end('Failed to read file');
+            return;
+        }
+
+        res.writeHead(200, { 'Content-Type': contentType });
+        res.end(buffer);
+    });
+}
+
+function resolveFileFromModulePath(candidatePath) {
+    if (!candidatePath || path.extname(candidatePath)) {
+        return candidatePath;
+    }
+
+    const possibleFiles = [
+        candidatePath,
+        `${candidatePath}.js`,
+        `${candidatePath}.mjs`,
+        `${candidatePath}.jsx`,
+        `${candidatePath}.ts`,
+        `${candidatePath}.tsx`,
+        path.join(candidatePath, 'index.js'),
+        path.join(candidatePath, 'index.mjs'),
+        path.join(candidatePath, 'index.jsx'),
+        path.join(candidatePath, 'index.ts'),
+        path.join(candidatePath, 'index.tsx')
+    ];
+
+    for (const filePath of possibleFiles) {
+        if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
+            return filePath;
+        }
+    }
+
+    return candidatePath;
+}
+
+function serveNotFound(res, pathname) {
+    res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end(`Not found: ${pathname}`);
+}
+
+const server = http.createServer((req, res) => {
+    const requestUrl = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+    const pathname = decodeURIComponent(requestUrl.pathname);
+
+    if (pathname === '/api/examples') {
+        sendJson(res, listExamples());
+        return;
+    }
+
+    if (pathname === '/' || pathname === '/index.html') {
+        sendFile(res, path.join(ROOT, 'index.html'));
+        return;
+    }
+
+    if (pathname === '/app.js') {
+        sendFile(res, path.join(ROOT, 'app.js'));
+        return;
+    }
+
+    if (pathname === '/dist' || pathname.startsWith('/dist/')) {
+        const relativeDistPath = pathname.replace(/^\/dist\/?/, '');
+        const resolvedDistPath = path.resolve(DIST_ROOT, relativeDistPath);
+        if (resolvedDistPath.startsWith(DIST_ROOT + path.sep)) {
+            const resolvedFile = resolveFileFromModulePath(resolvedDistPath);
+            if (fs.existsSync(resolvedFile) && fs.statSync(resolvedFile).isFile()) {
+                sendFile(res, resolvedFile);
+                return;
+            }
+        }
+        serveNotFound(res, pathname);
+        return;
+    }
+
+    const relativePath = pathname === '/' ? '' : pathname.replace(/^\//, '');
+    const resolvedPath = path.resolve(ROOT, relativePath);
+
+    if (!isWithinRoot(resolvedPath)) {
+        serveNotFound(res, pathname);
+        return;
+    }
+
+    if (fs.existsSync(resolvedPath) && fs.statSync(resolvedPath).isDirectory()) {
+        if (!pathname.endsWith('/')) {
+            res.writeHead(302, { Location: `${pathname}/` });
+            res.end();
+            return;
+        }
+
+        const indexFile = path.join(resolvedPath, 'index.html');
+        if (fs.existsSync(indexFile)) {
+            sendFile(res, indexFile);
+            return;
+        }
+    }
+
+    const resolvedFile = resolveFileFromModulePath(resolvedPath);
+    if (fs.existsSync(resolvedFile) && fs.statSync(resolvedFile).isFile()) {
+        sendFile(res, resolvedFile);
+        return;
+    }
+
+    serveNotFound(res, pathname);
+});
+
+server.listen(PORT, () => {
+    console.log(`Transmute examples are running at http://localhost:${PORT}`);
+    console.log('Open the root page to browse all examples.');
+});

--- a/examples/styles.css
+++ b/examples/styles.css
@@ -1,0 +1,375 @@
+:root {
+    color-scheme: light;
+    --accent: #c65436;
+    --accent-dark: #8f3525;
+    --ink: #17221f;
+    --line: #d7ded2;
+    --muted: #61716c;
+    --panel: #fffdf8;
+    --paper: #f4f6ef;
+    --success: #1e7656;
+    --teal: #2e7067;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    min-width: 320px;
+    min-height: 100vh;
+    background: var(--paper);
+    color: var(--ink);
+    font: 16px/1.5 Georgia, 'Times New Roman', serif;
+}
+
+main {
+    margin: 0 auto;
+    max-width: 900px;
+    padding: 0;
+}
+
+header {
+    background: var(--paper);
+    border-bottom: 1px solid var(--line);
+    margin-bottom: 24px;
+    padding-top: 24px;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+h1,
+h2,
+h3 {
+    font-weight: 400;
+    line-height: 1.05;
+    margin: 0;
+}
+
+h1 {
+    font-size: clamp(2.6rem, 7vw, 5.4rem);
+    letter-spacing: -.04em;
+}
+
+h2 {
+    font-size: 1.7rem;
+}
+
+h3 {
+    font-size: 1.25rem;
+}
+
+header p {
+    color: var(--muted);
+    font-size: 1.12rem;
+}
+
+.back {
+    color: var(--teal);
+    text-decoration: none;
+    text-transform: uppercase;
+}
+
+.back:hover {
+    text-decoration: underline;
+}
+
+.back-breadcrumb {
+    margin-bottom: 24px;
+}
+
+.eyebrow {
+    color: var(--accent-dark);
+    letter-spacing: .12em;
+    margin: 0 0 12px;
+    text-transform: uppercase;
+}
+
+.grid {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.form-grid {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.grid-item {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.fixed-list {
+    background: transparent;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.scrollable {
+    overflow-y: auto;
+}
+
+.layout {
+    align-items: start;
+    display: grid;
+    gap: 16px;
+    grid-template-columns: minmax(220px, 280px) 1fr;
+}
+
+section {
+    border-radius: 8px;
+    min-width: 0;
+    padding: 24px;
+}
+
+.sectionWithBorder {
+    background: color-mix(in srgb, var(--panel) 92%, transparent);
+    border: 1px solid var(--line);
+}
+
+input {
+    background: #fff;
+    border: 1px solid var(--line);
+    border-radius: 5px;
+    color: var(--ink);
+    font: inherit;
+    padding: 11px 12px;
+    width: 100%;
+}
+
+select {
+    background: #fff;
+    border: 1px solid var(--line);
+    border-radius: 5px;
+    color: var(--ink);
+    font: inherit;
+    padding: 11px 12px;
+    width: 100%;
+}
+
+label:not(.label) {
+    display: block;
+    margin: 16px 0 6px;
+}
+
+label:not(.label) input,
+label:not(.label) select {
+    margin-top: 6px;
+}
+
+.label {
+    color: var(--muted);
+    display: block;
+    font: 700 12px/1.2 'Trebuchet MS', sans-serif;
+    letter-spacing: .06em;
+    margin: 18px 0 6px;
+    text-transform: uppercase;
+}
+
+.actions,
+.button-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+button {
+    background: var(--accent);
+    border: 0;
+    border-radius: 5px;
+    color: white;
+    cursor: pointer;
+    font: 700 13px 'Trebuchet MS', sans-serif;
+    margin-top: 16px;
+    padding: 11px 15px;
+}
+
+button:hover {
+    background: var(--accent-dark);
+}
+
+button.secondary {
+    background: var(--teal);
+}
+
+button:disabled {
+    cursor: not-allowed;
+    opacity: .7;
+}
+
+.status {
+    color: var(--success);
+    font-size: smaller;
+    margin: 14px 0 0;
+    min-height: 28px;
+}
+
+.status.error {
+    color: var(--accent-dark);
+}
+
+.error {
+    color: var(--accent-dark);
+}
+
+.ok {
+    color: var(--success);
+}
+
+.chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 7px;
+    margin-top: 18px;
+}
+
+.chip {
+    background: #eef6f1;
+    border: 1px solid #b8ccc4;
+    border-radius: 999px;
+    color: var(--teal);
+    font: 700 12px 'Trebuchet MS', sans-serif;
+    padding: 5px 9px;
+}
+
+article,
+aside {
+    background: color-mix(in srgb, var(--panel) 92%, transparent);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    min-width: 0;
+    padding: 24px;
+}
+
+.user-list {
+    display: grid;
+    gap: 8px;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.user-list button {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    margin-top: 0;
+    text-align: left;
+    width: 100%;
+}
+
+.user-list button.selected {
+    background: var(--teal);
+}
+
+.badge {
+    background: #d9ece6;
+    border-radius: 999px;
+    color: #1e5850;
+    font-size: 12px;
+    line-height: 1;
+    padding: 4px 8px;
+}
+
+.rules-panel {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 14px;
+}
+
+.example-list {
+    display: grid;
+    gap: 10px;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.example-list li {
+    background: color-mix(in srgb, var(--panel) 92%, transparent);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+}
+
+.example-list a {
+    color: var(--ink);
+    display: block;
+    font-size: 1.05rem;
+    padding: 14px 16px;
+    text-decoration: none;
+}
+
+.example-list a:hover {
+    background: #eff3e8;
+    border-radius: 8px;
+    color: var(--accent-dark);
+}
+
+code {
+    background: #edf1e8;
+    border-radius: 4px;
+    padding: 2px 5px;
+}
+
+pre {
+    background: #1e2d29;
+    border-radius: 5px;
+    color: #e4f0e6;
+    font: 13px/1.45 Consolas, monospace;
+    overflow: auto;
+    padding: 14px;
+    white-space: pre-wrap;
+}
+
+.note {
+    color: var(--muted);
+    font-size: .95rem;
+}
+
+.marginTopZero {
+    margin-top: 0;
+}
+
+.paddingTopZero {
+    padding-top: 0;
+}
+
+section.wide {
+    grid-column: 1 / -1;
+}
+
+@media (max-width: 720px) {
+    main {
+        padding-inline: 16px;
+    }
+
+    header {
+        padding-top: 38px;
+    }
+
+    .grid {
+        grid-template-columns: 1fr;
+    }
+
+    section.wide {
+        grid-column: auto;
+    }
+
+    .layout {
+        grid-template-columns: 1fr;
+    }
+
+    .form-grid,
+    .grid {
+        grid-template-columns: 1fr;
+    }
+}


### PR DESCRIPTION
- document the complete Transmute API and validation workflows
- add six interactive browser examples
- add shared example navigation and development server
- demonstrate context-aware, async, collection, and dynamic rules
- include a full user-directory editing and rollback flow
- update ESLint configuration for example sources

Partially fixes: #7 